### PR TITLE
[codex] Enforce form request validation

### DIFF
--- a/.claude/hooks/post-edit-check.sh
+++ b/.claude/hooks/post-edit-check.sh
@@ -12,6 +12,15 @@ PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 case "$EXT" in
   php)
+    # Enforce Form Request based input validation in controllers.
+    if [[ "$FILE_PATH" == *"/app/Http/Controllers/"* ]]; then
+      if grep -nE '(\$request->validate\(|request\(\)->validate\()' "$FILE_PATH" >/tmp/form-request-validation-check.txt; then
+        echo "BLOCK: Controller input validation must use a Form Request object."
+        cat /tmp/form-request-validation-check.txt
+        echo "Move rules to app/Http/Requests/** and read validated data with \$request->validated()."
+      fi
+    fi
+
     # Run PHPStan on the file
     if [ -f "$PROJECT_ROOT/vendor/bin/phpstan" ]; then
       echo "📋 Analyzing: $(basename "$FILE_PATH")"

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -18,6 +18,22 @@ if [ -n "$STAGED_PHP" ]; then
   echo ">>> PHP: Running Pint..."
   cd "$PROJECT_DIR"
 
+  CONTROLLER_VALIDATION=""
+  while IFS= read -r FILE; do
+    [ -z "$FILE" ] && continue
+    MATCHES=$(grep -nE '(\$request->validate\(|request\(\)->validate\()' "$FILE" 2>/dev/null || true)
+    if [ -n "$MATCHES" ]; then
+      CONTROLLER_VALIDATION="${CONTROLLER_VALIDATION}${FILE}:${MATCHES}
+"
+    fi
+  done < <(printf '%s\n' "$STAGED_PHP" | grep '^src/app/Http/Controllers/.*\.php$' || true)
+  if [ -n "$CONTROLLER_VALIDATION" ]; then
+    echo "BLOCK: Controller input validation must use Form Request objects."
+    echo "$CONTROLLER_VALIDATION"
+    echo "Move rules to app/Http/Requests/** and read validated data with \$request->validated()."
+    ERRORS=1
+  fi
+
   if ! ./vendor/bin/pint --test 2>&1; then
     echo "BLOCK: Pint found formatting issues. Run: composer pint"
     ERRORS=1

--- a/.claude/rules/laravel/form-request-validation.md
+++ b/.claude/rules/laravel/form-request-validation.md
@@ -1,0 +1,37 @@
+---
+globs: ["src/app/Http/Controllers/**/*.php","src/app/Http/Requests/**/*.php"]
+---
+
+# Form Request Validation
+
+HTTP リクエストの入力検証は Form Request オブジェクト経由に統一する。
+
+## 必須ルール
+
+- Controller で `$request->validate([...])` を使わない
+- Controller で `request()->validate([...])` を使わない
+- バリデーションルールは `app/Http/Requests/**` 配下の `FormRequest` サブクラスの `rules()` に定義する
+- Controller のアクション引数には用途別の Form Request を型指定する
+- Controller では `$request->validated()` で検証済みデータを取得する
+
+## 例
+
+```php
+// Good
+public function store(StoreUserRequest $request): RedirectResponse
+{
+    $validated = $request->validated();
+}
+
+// Bad
+public function store(Request $request): RedirectResponse
+{
+    $validated = $request->validate([
+        'email' => ['required', 'email'],
+    ]);
+}
+```
+
+## 例外
+
+`Auth::guard()->validate([...])` のような、Laravel 認証ガードや外部サービスの `validate` メソッドは対象外。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Kiro-style Spec Driven Development implementation on AI-DLC (AI Development Life
 - Human review required each phase; use `-y` only for intentional fast-track
 - Keep steering current and verify alignment with `/kiro:spec-status`
 - Follow the user's instructions precisely, and within that scope act autonomously: gather the necessary context and complete the requested work end-to-end in this run, asking questions only when essential information is missing or the instructions are critically ambiguous.
+- HTTP 入力検証は `.claude/rules/laravel/form-request-validation.md` に従い、Controller の `$request->validate()` ではなく Form Request 経由に統一する
 
 ## Steering Configuration
 - Load entire `.kiro/steering/` as project memory

--- a/src/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/src/app/Http/Controllers/Auth/NewPasswordController.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\StoreNewPasswordRequest;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
-use Illuminate\Validation\Rules;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -34,22 +34,18 @@ class NewPasswordController extends Controller
      *
      * @throws ValidationException
      */
-    public function store(Request $request): RedirectResponse
+    public function store(StoreNewPasswordRequest $request): RedirectResponse
     {
-        $request->validate([
-            'token' => 'required',
-            'email' => 'required|email',
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
-        ]);
+        $validated = $request->validated();
 
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
         // database. Otherwise we will parse the error and return the response.
         $status = Password::reset(
-            $request->only('email', 'password', 'password_confirmation', 'token'),
-            function ($user) use ($request) {
+            $validated,
+            function ($user) use ($validated) {
                 $user->forceFill([
-                    'password' => Hash::make($request->password),
+                    'password' => Hash::make($validated['password']),
                     'remember_token' => Str::random(60),
                 ])->save();
 

--- a/src/app/Http/Controllers/Auth/PasswordController.php
+++ b/src/app/Http/Controllers/Auth/PasswordController.php
@@ -5,22 +5,18 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\UpdatePasswordRequest;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\Rules\Password;
 
 class PasswordController extends Controller
 {
     /**
      * Update the user's password.
      */
-    public function update(Request $request): RedirectResponse
+    public function update(UpdatePasswordRequest $request): RedirectResponse
     {
-        $validated = $request->validate([
-            'current_password' => ['required', 'current_password'],
-            'password' => ['required', Password::defaults(), 'confirmed'],
-        ]);
+        $validated = $request->validated();
 
         $request->user()->update([
             'password' => Hash::make($validated['password']),

--- a/src/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/src/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\PasswordResetLinkRequest;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
@@ -29,17 +29,15 @@ class PasswordResetLinkController extends Controller
      *
      * @throws ValidationException
      */
-    public function store(Request $request): RedirectResponse
+    public function store(PasswordResetLinkRequest $request): RedirectResponse
     {
-        $request->validate([
-            'email' => 'required|email',
-        ]);
+        $validated = $request->validated();
 
         // We will send the password reset link to this user. Once we have attempted
         // to send the link, we will examine the response then see the message we
         // need to show to the user. Finally, we'll send out a proper response.
         $status = Password::sendResetLink(
-            $request->only('email')
+            $validated
         );
 
         if ($status == Password::RESET_LINK_SENT) {

--- a/src/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/src/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\RegisterUserRequest;
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\Rules;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -31,18 +30,14 @@ class RegisteredUserController extends Controller
      *
      * @throws ValidationException
      */
-    public function store(Request $request): RedirectResponse
+    public function store(RegisterUserRequest $request): RedirectResponse
     {
-        $request->validate([
-            'name' => 'required|string|max:255',
-            'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
-        ]);
+        $validated = $request->validated();
 
         $user = User::create([
-            'name' => $request->name,
-            'email' => $request->email,
-            'password' => Hash::make($request->password),
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => Hash::make($validated['password']),
         ]);
 
         event(new Registered($user));

--- a/src/app/Http/Controllers/ProfileController.php
+++ b/src/app/Http/Controllers/ProfileController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\DeleteProfileRequest;
 use App\Http\Requests\ProfileUpdateRequest;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Http\RedirectResponse;
@@ -45,12 +46,8 @@ class ProfileController extends Controller
     /**
      * Delete the user's account.
      */
-    public function destroy(Request $request): RedirectResponse
+    public function destroy(DeleteProfileRequest $request): RedirectResponse
     {
-        $request->validate([
-            'password' => ['required', 'current_password'],
-        ]);
-
         $user = $request->user();
 
         Auth::logout();

--- a/src/app/Http/Requests/Auth/PasswordResetLinkRequest.php
+++ b/src/app/Http/Requests/Auth/PasswordResetLinkRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class PasswordResetLinkRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|email',
+        ];
+    }
+}

--- a/src/app/Http/Requests/Auth/RegisterUserRequest.php
+++ b/src/app/Http/Requests/Auth/RegisterUserRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules;
+
+class RegisterUserRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+        ];
+    }
+}

--- a/src/app/Http/Requests/Auth/StoreNewPasswordRequest.php
+++ b/src/app/Http/Requests/Auth/StoreNewPasswordRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules;
+
+class StoreNewPasswordRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'token' => 'required',
+            'email' => 'required|email',
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'password_confirmation' => 'required|string',
+        ];
+    }
+}

--- a/src/app/Http/Requests/Auth/UpdatePasswordRequest.php
+++ b/src/app/Http/Requests/Auth/UpdatePasswordRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class UpdatePasswordRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'current_password' => ['required', 'current_password'],
+            'password' => ['required', Password::defaults(), 'confirmed'],
+        ];
+    }
+}

--- a/src/app/Http/Requests/DeleteProfileRequest.php
+++ b/src/app/Http/Requests/DeleteProfileRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteProfileRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'password' => ['required', 'current_password'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- Add a Laravel rule requiring HTTP input validation to go through Form Request objects.
- Add edit/pre-commit checks that flag direct controller `$request->validate()` and `request()->validate()` usage.
- Move Breeze template controller validation for registration, password reset/update, and profile deletion into dedicated Form Request classes.

## Why

The template still generated controller-local validation, so downstream apps inherited `$request->validate()` usage even when project rules prefer Form Requests. This makes new projects start with the intended validation structure and catches regressions before commit.

## Validation

- `bash -n .claude/hooks/post-edit-check.sh`
- `bash -n .claude/hooks/pre-commit-check.sh`
- `rg -n '\$request->validate\(|request\(\)->validate\(' src/app/Http/Controllers src/app/Http/Requests` returned no matches
- `docker compose exec app ./vendor/bin/pint ...` on changed PHP files
- `docker compose exec -e APP_KEY=base64:... app npm run build`
- `docker compose exec -e APP_KEY=base64:... app php artisan test` exited 0; warnings remain because this fresh template worktree has no `.env`
- `docker compose exec -e APP_KEY=base64:... app ./vendor/bin/phpstan analyse --no-progress`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ユーザー登録、パスワード変更・再設定、プロフィール削除の入力検証を専用のリクエスト処理に統一しました。
  * 検証済みデータのみを各処理で使用するようになり、入力内容の一貫性と安全性が向上しました。

* **ドキュメント**
  * 入力検証に関する開発ルールを追加しました。

* **品質向上**
  * コントローラ内で直接入力検証を行う記述を検出し、編集後およびコミット時に通知・阻止できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->