### PR TITLE
[codex] Document model layer boundaries

### DIFF
--- a/.claude/hooks/post-edit-check.sh
+++ b/.claude/hooks/post-edit-check.sh
@@ -12,6 +12,15 @@ PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 case "$EXT" in
   php)
+    # Service / Action classes become generic buckets; keep logic in Models.
+    if [[ "$FILE_PATH" == *"/app/Services/"* || "$FILE_PATH" == *"/app/Actions/"* ]]; then
+      echo "BLOCK: Service / Action classes are not allowed."
+      echo "Place DB logic in Eloquent Models, external API logic in Models/Gateway, and shared model behavior in Models/Concerns."
+    elif [[ "$FILE_PATH" == *Service.php && "$FILE_PATH" != *"/app/Providers/"*ServiceProvider.php ]]; then
+      echo "BLOCK: Service classes are not allowed."
+      echo "Place DB logic in Eloquent Models, external API logic in Models/Gateway, and shared model behavior in Models/Concerns."
+    fi
+
     # Enforce Form Request based input validation in controllers.
     if [[ "$FILE_PATH" == *"/app/Http/Controllers/"* ]]; then
       if grep -nE '(\$request->validate\(|request\(\)->validate\()' "$FILE_PATH" >/tmp/form-request-validation-check.txt; then

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -18,6 +18,30 @@ if [ -n "$STAGED_PHP" ]; then
   echo ">>> PHP: Running Pint..."
   cd "$PROJECT_DIR"
 
+  SERVICE_LAYER_FILES=""
+  while IFS= read -r FILE; do
+    [ -z "$FILE" ] && continue
+
+    if [[ "$FILE" == src/app/Services/* || "$FILE" == src/app/Actions/* ]]; then
+      SERVICE_LAYER_FILES="${SERVICE_LAYER_FILES}${FILE}
+"
+      continue
+    fi
+
+    if [[ "$FILE" == src/app/*Service.php || "$FILE" == src/app/**/*Service.php ]]; then
+      if [[ "$FILE" != src/app/Providers/*ServiceProvider.php ]]; then
+        SERVICE_LAYER_FILES="${SERVICE_LAYER_FILES}${FILE}
+"
+      fi
+    fi
+  done < <(printf '%s\n' "$STAGED_PHP")
+  if [ -n "$SERVICE_LAYER_FILES" ]; then
+    echo "BLOCK: Service / Action classes are not allowed."
+    echo "$SERVICE_LAYER_FILES"
+    echo "Place DB logic in Eloquent Models, external API logic in Models/Gateway, and shared model behavior in Models/Concerns."
+    ERRORS=1
+  fi
+
   CONTROLLER_VALIDATION=""
   while IFS= read -r FILE; do
     [ -z "$FILE" ] && continue

--- a/.claude/rules/laravel/model-layer-boundaries.md
+++ b/.claude/rules/laravel/model-layer-boundaries.md
@@ -1,0 +1,84 @@
+---
+globs: ["src/app/**/*.php"]
+---
+
+# Model Layer Boundaries
+
+アプリケーションの基本処理は Model 層に寄せる。Controller は HTTP 入出力、Form Request、認可、レスポンス制御に集中させる。
+
+## Service / Action クラスは禁止
+
+`app/Services/**` や `app/Actions/**` にユースケース処理を集めない。
+
+Service クラスは禁止する。何でも入る便利な置き場になりやすく、責務境界が曖昧になって Controller の代わりに肥大化するため。
+
+例外:
+
+- Laravel の `ServiceProvider`
+- フレームワークや外部ライブラリが要求する provider / contract 実装
+
+## Eloquent Model
+
+DB 永続化を持つものは Eloquent Model に書く。ORM の責務は Eloquent に置く。
+
+書くもの:
+
+- relationships
+- scopes
+- casts
+- accessor / mutator
+- そのレコード自身の状態判定
+- そのレコード自身の状態変更
+- その Model の不変条件を守る処理
+
+書かないもの:
+
+- HTTP Request / Response 処理
+- 外部 API 呼び出し
+- provider 固有の認証や payload 組み立て
+- 複数外部サービスの連携処理
+
+## Gateway Model
+
+外部サービス/API 接続は `App\Models\Gateway` に置く。インフラサービスは Gateway Model として表現し、Controller や Eloquent Model に通信仕様を漏らさない。
+
+書くもの:
+
+- HTTP client 呼び出し
+- endpoint / payload / response mapping
+- provider 固有の認証
+- provider 固有のエラー変換
+- 外部リソースを表す軽量な Model
+
+例:
+
+- `App\Models\Gateway\OpenRouter\ChatCompletion`
+- `App\Models\Gateway\SendGrid\Mail`
+- `App\Models\Gateway\WebPush\Subscription`
+
+## Concerns / Traits
+
+共通振る舞いは `App\Models\Concerns` の Trait に切り出す。
+
+Trait / Concern を使う条件:
+
+- 2 つ以上の Model で同じ振る舞いが必要
+- 継承関係では表現しない方がよい
+- 状態や責務が小さく閉じている
+- Trait 名だけで責務が分かる
+
+避けるもの:
+
+- 1 つの Model でしか使っていない
+- 外部 API 呼び出しを含む
+- DB transaction を含む
+- private / protected メソッド共有が主目的
+- 便利メソッド置き場になっている
+
+## 判断フロー
+
+1. DB レコードそのものの話なら Eloquent Model に書く
+2. 外部サービスのリソースや API 操作なら Gateway Model に書く
+3. 複数 Model に共通する小さい性質なら Concern に切り出す
+4. Controller は Form Request と Model 呼び出しだけに寄せる
+5. 迷う場合も Service クラスは作らず、Eloquent / Gateway / Concern のどれの責務かを先に決める

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Kiro-style Spec Driven Development implementation on AI-DLC (AI Development Life
 - Keep steering current and verify alignment with `/kiro:spec-status`
 - Follow the user's instructions precisely, and within that scope act autonomously: gather the necessary context and complete the requested work end-to-end in this run, asking questions only when essential information is missing or the instructions are critically ambiguous.
 - HTTP 入力検証は `.claude/rules/laravel/form-request-validation.md` に従い、Controller の `$request->validate()` ではなく Form Request 経由に統一する
+- Service クラスは禁止し、DB 永続化は Eloquent Model、外部接続は Gateway Model、共通振る舞いは Concerns に置く。詳細は `.claude/rules/laravel/model-layer-boundaries.md` を参照
 
 ## Steering Configuration
 - Load entire `.kiro/steering/` as project memory


### PR DESCRIPTION
## Summary

- Add a Laravel rule for model-layer responsibility boundaries.
- Explicitly prohibit generic Service / Action classes as application logic buckets.
- Document where to put Eloquent ORM logic, external API Gateway Models, and shared Model Concerns.
- Add edit/pre-commit checks that flag `app/Services`, `app/Actions`, and `*Service.php` while allowing Laravel `ServiceProvider` classes.

## Why

Generic Service classes tend to become catch-all containers and blur responsibility boundaries. The template should guide downstream apps toward Eloquent Models for ORM behavior, Gateway Models for infrastructure/external APIs, and Concerns for small reusable model behavior.

## Validation

- `bash -n .claude/hooks/post-edit-check.sh`
- `bash -n .claude/hooks/pre-commit-check.sh`
- local shell pattern check verified `AppServiceProvider` is allowed while `FooService`, `app/Services/**`, and `app/Actions/**` are blocked