### PR TITLE
[codex] Enforce generated TypeScript types

### DIFF
--- a/.claude/hooks/post-edit-check.sh
+++ b/.claude/hooks/post-edit-check.sh
@@ -37,6 +37,20 @@ case "$EXT" in
     fi
     ;;
   ts|tsx)
+    if grep -nE '(:| as |<|,|\(|\[|\{|=)\s*any\b|Array<\s*any\s*>|Record<[^>]*,\s*any\s*>' "$FILE_PATH" >/tmp/type-safety-any-check.txt; then
+      echo "BLOCK: TypeScript any is not allowed."
+      cat /tmp/type-safety-any-check.txt
+      echo "Use generated Data types, precise local Props, unknown, or a generic type parameter instead."
+    fi
+
+    if [[ "$FILE_PATH" == *"/resources/js/types/"* && "$FILE_PATH" != *"/resources/js/types/generated.d.ts" && "$FILE_PATH" != *"/resources/js/types/vite-env.d.ts" ]]; then
+      if grep -nE '^\s*export\s+(interface|type)\s+' "$FILE_PATH" >/tmp/type-safety-manual-types-check.txt; then
+        echo "BLOCK: Manual exported types under resources/js/types are not allowed."
+        cat /tmp/type-safety-manual-types-check.txt
+        echo "Create app/Data/** with #[TypeScript], run php artisan typescript:transform, and use resources/js/types/generated.d.ts."
+      fi
+    fi
+
     # Run TypeScript check
     if [ -f "$PROJECT_ROOT/node_modules/.bin/tsc" ]; then
       echo "📋 Type checking: $(basename "$FILE_PATH")"
@@ -45,6 +59,12 @@ case "$EXT" in
     fi
     ;;
   js|jsx)
+    if grep -nE '(:| as |<|,|\(|\[|\{|=)\s*any\b|Array<\s*any\s*>|Record<[^>]*,\s*any\s*>' "$FILE_PATH" >/tmp/type-safety-any-check.txt; then
+      echo "BLOCK: TypeScript any is not allowed."
+      cat /tmp/type-safety-any-check.txt
+      echo "Use generated Data types, precise local Props, unknown, or a generic type parameter instead."
+    fi
+
     # Run Biome lint
     if [ -f "$PROJECT_ROOT/node_modules/.bin/biome" ]; then
       echo "📋 Linting: $(basename "$FILE_PATH")"

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -82,6 +82,37 @@ if [ -n "$STAGED_TS" ]; then
   ORIGINAL_DIR=$(pwd)
   cd "$PROJECT_DIR/src"
 
+  TYPE_SAFETY_ERRORS=""
+  while IFS= read -r FILE; do
+    [ -z "$FILE" ] && continue
+
+    ADDED_LINES=$(git -C "$PROJECT_DIR" diff --cached -U0 -- "$FILE" | grep '^+' | grep -v '^+++' || true)
+
+    if [ -n "$ADDED_LINES" ]; then
+      ANY_MATCHES=$(printf '%s\n' "$ADDED_LINES" | grep -nE '(:| as |<|,|\(|\[|\{|=)\s*any\b|Array<\s*any\s*>|Record<[^>]*,\s*any\s*>' || true)
+      if [ -n "$ANY_MATCHES" ]; then
+        TYPE_SAFETY_ERRORS="${TYPE_SAFETY_ERRORS}${FILE}: TypeScript any is not allowed.
+${ANY_MATCHES}
+"
+      fi
+
+      if [[ "$FILE" == src/resources/js/types/* && "$FILE" != src/resources/js/types/generated.d.ts && "$FILE" != src/resources/js/types/vite-env.d.ts ]]; then
+        MANUAL_TYPES=$(printf '%s\n' "$ADDED_LINES" | grep -nE '^\+\s*export\s+(interface|type)\s+' || true)
+        if [ -n "$MANUAL_TYPES" ]; then
+          TYPE_SAFETY_ERRORS="${TYPE_SAFETY_ERRORS}${FILE}: Manual exported types under resources/js/types are not allowed.
+${MANUAL_TYPES}
+"
+        fi
+      fi
+    fi
+  done < <(printf '%s\n' "$STAGED_TS")
+  if [ -n "$TYPE_SAFETY_ERRORS" ]; then
+    echo "BLOCK: TypeScript types must come from Laravel Data generated types."
+    echo "$TYPE_SAFETY_ERRORS"
+    echo "Create app/Data/** with #[TypeScript], run php artisan typescript:transform, and avoid any."
+    ERRORS=1
+  fi
+
   if ! npm run lint:js 2>&1; then
     echo "BLOCK: Biome lint failed"
     ERRORS=1

--- a/.claude/rules/type-safety.md
+++ b/.claude/rules/type-safety.md
@@ -18,6 +18,20 @@
 - `interface` または `type` を types/ 配下に書こうとした時
 - `export interface` を手動で追加しようとした時
 - Controller から Inertia にデータを渡す型が必要な時
+- `any` 型を追加しようとした時
+
+### 強制ブロック
+
+pre-commit hook は staged diff の追加行を検査し、以下をブロックする:
+
+- TypeScript / TSX / JS / JSX への `any` 型追加
+- `resources/js/types/**` 配下への手動 `export interface` / `export type` 追加
+
+例外:
+
+- `resources/js/types/generated.d.ts`: `php artisan typescript:transform` による自動生成のみ
+- `resources/js/types/vite-env.d.ts`: Vite の ambient reference
+- component 内のローカル Props 型。ただし `any` は使わない
 
 ### 許可される型定義
 


### PR DESCRIPTION
## Summary

- Make the type-safety rule explicit about enforced blocking.
- Add post-edit warnings for TypeScript `any` and manual exported types under `resources/js/types/**`.
- Add pre-commit blocking for staged additions of `any` and manual `export interface` / `export type` under `resources/js/types/**`.

## Why

The template already documents Data-class-driven TypeScript generation. This adds mechanical guardrails so downstream projects do not drift into hand-written API/model types or `any`.

## Validation

- `bash -n .claude/hooks/post-edit-check.sh`
- `bash -n .claude/hooks/pre-commit-check.sh`
- `rg` check confirmed current `src/resources/js` has no matching TypeScript `any` patterns.