### PR TITLE
設計規約を Pest arch テストで強制する

### DIFF
--- a/.claude/rules/testing/architecture-tests.md
+++ b/.claude/rules/testing/architecture-tests.md
@@ -1,0 +1,33 @@
+---
+globs: ["src/tests/Arch/**/*.php","src/app/**/*.php","src/phpunit.xml"]
+---
+
+# Architecture Tests
+
+`.claude/rules/**` に書いた設計ルールのうち、機械的に判定できるものは `tests/Arch/**` の Pest arch テストで強制する。文書だけのルールは守られないため、レビュー待ちにせず CI で落とす。
+
+## 構成
+
+| ファイル | 内容 |
+| --- | --- |
+| `tests/Arch/PresetsTest.php` | Pest の `php` / `security` / `laravel` preset |
+| `tests/Arch/LayerBoundariesTest.php` | Model 層境界と Controller の責務（`model-layer-boundaries.md` / `form-request-validation.md` 由来） |
+| `tests/Arch/CodingStandardsTest.php` | strict types（`php.md` 由来） |
+| `tests/Arch/PrecognitionTest.php` | Form Request を使う変更系 route の Precognition middleware（`form-request-validation.md` 由来） |
+
+`phpunit.xml` に `Arch` testsuite を定義してあるので、`php artisan test` で他のスイートと一緒に走る。arch だけ流すときは `php artisan test --testsuite=Arch`。
+
+## 書き方
+
+- 1 つの `arch()` に 1 つのルールを書き、説明文に日本語でルール名を書く。失敗時にどの規約に違反したか分かるようにする
+- 対応する規約ファイルをコメントで示し、規約とテストが対で追えるようにする
+- ディレクトリの不存在のように arch API で表現できないものは通常の `it()` で書く
+- `laravel` preset は Eloquent Model 前提の検査を含むため、DB 永続化しない `App\Models\Gateway` は `ignoring()` で対象外にする
+
+## 規約を追加したとき
+
+`.claude/rules/**` に新しい設計ルールを追加したら、機械判定できるかを検討し、可能なら arch テストも足す。判定できない場合はレビュー観点として規約側に残す。
+
+## BDD フローとの関係
+
+`tests/Arch/**` は `.claude/rules/testing/feature-test-policy.md` の BDD フロー（requirements.md と Gherkin シナリオ必須）の対象外。ユーザー向け振る舞いではなく実装構造の検査なので、`scenario()` ヘルパーも使わない。

--- a/.claude/rules/testing/architecture-tests.md
+++ b/.claude/rules/testing/architecture-tests.md
@@ -14,6 +14,7 @@ globs: ["src/tests/Arch/**/*.php","src/app/**/*.php","src/phpunit.xml"]
 | `tests/Arch/LayerBoundariesTest.php` | Model 層境界と Controller の責務（`model-layer-boundaries.md` / `form-request-validation.md` 由来） |
 | `tests/Arch/CodingStandardsTest.php` | strict types（`php.md` 由来） |
 | `tests/Arch/PrecognitionTest.php` | Form Request を使う変更系 route の Precognition middleware（`form-request-validation.md` 由来） |
+| `tests/Arch/RequestValidationTest.php` | Controller での `$request->validate()` / `request()->validate()` 禁止（`form-request-validation.md` 由来） |
 
 `phpunit.xml` に `Arch` testsuite を定義してあるので、`php artisan test` で他のスイートと一緒に走る。arch だけ流すときは `php artisan test --testsuite=Arch`。
 
@@ -21,7 +22,7 @@ globs: ["src/tests/Arch/**/*.php","src/app/**/*.php","src/phpunit.xml"]
 
 - 1 つの `arch()` に 1 つのルールを書き、説明文に日本語でルール名を書く。失敗時にどの規約に違反したか分かるようにする
 - 対応する規約ファイルをコメントで示し、規約とテストが対で追えるようにする
-- ディレクトリの不存在のように arch API で表現できないものは通常の `it()` で書く
+- ディレクトリの不存在やメソッド呼び出しのように arch API で表現できないものは通常の `it()` で書く。呼び出しの検査は正規表現ではなく `token_get_all()` のトークン列で判定し、コメントや文字列リテラルを誤検出しない
 - `laravel` preset は Eloquent Model 前提の検査を含むため、DB 永続化しない `App\Models\Gateway` は `ignoring()` で対象外にする
 
 ## 規約を追加したとき

--- a/.claude/rules/testing/feature-test-policy.md
+++ b/.claude/rules/testing/feature-test-policy.md
@@ -128,5 +128,6 @@ Feature テストを直接作成することはできません。
 |------|----------|------|
 | Feature テスト | requirements.md + Gherkin 必須 | 必須 |
 | Unit テスト | 実装コードがあれば可 | 不要 |
+| Arch テスト | 規約が決まっていれば可 | 不要 |
 
-Unit テスト (`tests/Unit/`) はこのルールの対象外。
+Unit テスト (`tests/Unit/`) と Arch テスト (`tests/Arch/`) はこのルールの対象外。Arch テストの方針は `.claude/rules/testing/architecture-tests.md` を参照。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Kiro-style Spec Driven Development implementation on AI-DLC (AI Development Life
 - Form Request を使う変更系 route は Laravel Precognition に対応し、React フォームは Inertia の Precognition API でライブ検証する
 - Inertia props は `.claude/rules/laravel/inertia-props.md` に従い、モデル/API レスポンス由来の構造化データを Data DTO 経由で渡す
 - Service クラスは禁止し、DB 永続化は Eloquent Model、外部接続は Gateway Model、共通振る舞いは Concerns に置く。詳細は `.claude/rules/laravel/model-layer-boundaries.md` を参照
+- 機械判定できる設計ルールは `tests/Arch/**` の Pest arch テストで強制する。規約を追加したら arch テストも検討する。詳細は `.claude/rules/testing/architecture-tests.md` を参照
 - React 側は Inertia の Pages を入口として残し、feature 固有 UI / hooks / helpers は `features/{feature}` に置く。詳細は `.claude/rules/frontend/architecture.md` を参照
 - フロント品質ゲートは `.claude/rules/frontend/quality-scans.md` に従い、Biome / TypeScript / knip / jscpd を CI で実行する
 

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -11,6 +11,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Arch">
+            <directory>tests/Arch</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/src/tests/Arch/CodingStandardsTest.php
+++ b/src/tests/Arch/CodingStandardsTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+// .claude/rules/php.md の型宣言・strict types ルールを実行可能な形にした検査。
+
+arch('アプリケーションコードは strict types を宣言する')
+    ->expect('App')
+    ->toUseStrictTypes();
+
+arch('テストコードも strict types を宣言する')
+    ->expect('Tests')
+    ->toUseStrictTypes();

--- a/src/tests/Arch/LayerBoundariesTest.php
+++ b/src/tests/Arch/LayerBoundariesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Validator;
+
+// .claude/rules/laravel/model-layer-boundaries.md を実行可能な形にした検査。
+
+it('Service / Action レイヤーを作らない', function () {
+    expect(is_dir(app_path('Services')))->toBeFalse()
+        ->and(is_dir(app_path('Actions')))->toBeFalse();
+});
+
+arch('Service 接尾辞のクラスを作らない')
+    ->expect('App')
+    ->not->toHaveSuffix('Service');
+
+arch('Eloquent Model は Eloquent の Model を継承する')
+    ->expect('App\Models\Eloquent')
+    ->toExtend(Model::class);
+
+arch('Eloquent Model から外部 API を呼ばない')
+    ->expect('App\Models\Eloquent')
+    ->not->toUse(Http::class);
+
+arch('Gateway Model は Gateway の基底クラスを継承する')
+    ->expect('App\Models\Gateway')
+    ->classes()
+    ->toExtend('App\Models\Gateway\Model')
+    ->ignoring('App\Models\Gateway\Model');
+
+arch('Gateway Model は DB 永続化しない')
+    ->expect('App\Models\Gateway')
+    ->not->toUse([Model::class, DB::class]);
+
+arch('Concerns は Trait として書く')
+    ->expect('App\Models\Concerns')
+    ->toBeTraits();
+
+// .claude/rules/laravel/form-request-validation.md の Controller 側ルール。
+
+arch('Controller は入力検証を Form Request に委ねる')
+    ->expect('App\Http\Controllers')
+    ->not->toUse(Validator::class);
+
+arch('Controller から DB ファサードを直接使わない')
+    ->expect('App\Http\Controllers')
+    ->not->toUse(DB::class);

--- a/src/tests/Arch/PrecognitionTest.php
+++ b/src/tests/Arch/PrecognitionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as RouteFacade;
+
+// .claude/rules/laravel/form-request-validation.md:
+// Form Request を使う変更系 route には HandlePrecognitiveRequests を付ける。
+// これが漏れるとフロントの validate() がライブ検証ではなく本処理を実行してしまう。
+
+it('Form Request を使う変更系 route には Precognition middleware が付いている', function () {
+    $usesFormRequest = function (Route $route): bool {
+        $controller = $route->getControllerClass();
+
+        if ($controller === null || ! class_exists($controller)) {
+            return false;
+        }
+
+        try {
+            $method = new ReflectionMethod($controller, $route->getActionMethod());
+        } catch (ReflectionException) {
+            return false;
+        }
+
+        foreach ($method->getParameters() as $parameter) {
+            $type = $parameter->getType();
+
+            if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+                continue;
+            }
+
+            if (is_subclass_of($type->getName(), FormRequest::class)) {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    $writeMethods = ['POST', 'PUT', 'PATCH', 'DELETE'];
+    $checked = 0;
+    $missing = [];
+
+    foreach (RouteFacade::getRoutes() as $route) {
+        if (array_intersect($writeMethods, $route->methods()) === [] || ! $usesFormRequest($route)) {
+            continue;
+        }
+
+        $checked++;
+
+        if (! in_array(HandlePrecognitiveRequests::class, $route->gatherMiddleware(), true)) {
+            $missing[] = implode('|', $route->methods()).' /'.$route->uri();
+        }
+    }
+
+    expect($checked)->toBeGreaterThan(0)
+        ->and($missing)->toBe([]);
+});

--- a/src/tests/Arch/PrecognitionTest.php
+++ b/src/tests/Arch/PrecognitionTest.php
@@ -12,16 +12,31 @@ use Illuminate\Support\Facades\Route as RouteFacade;
 // これが漏れるとフロントの validate() がライブ検証ではなく本処理を実行してしまう。
 
 it('Form Request を使う変更系 route には Precognition middleware が付いている', function () {
-    $usesFormRequest = function (Route $route): bool {
+    // controller action だけでなくクロージャ route も対象にする。
+    $reflectAction = function (Route $route): ?ReflectionFunctionAbstract {
+        $action = $route->getAction('uses');
+
+        if ($action instanceof Closure) {
+            return new ReflectionFunction($action);
+        }
+
         $controller = $route->getControllerClass();
 
         if ($controller === null || ! class_exists($controller)) {
-            return false;
+            return null;
         }
 
         try {
-            $method = new ReflectionMethod($controller, $route->getActionMethod());
+            return new ReflectionMethod($controller, $route->getActionMethod());
         } catch (ReflectionException) {
+            return null;
+        }
+    };
+
+    $usesFormRequest = function (Route $route) use ($reflectAction): bool {
+        $method = $reflectAction($route);
+
+        if ($method === null) {
             return false;
         }
 

--- a/src/tests/Arch/PresetsTest.php
+++ b/src/tests/Arch/PresetsTest.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+arch()->preset()->php();
+
+arch()->preset()->security();
+
+// App\Models\Gateway は DB 永続化しない外部接続レイヤーなので、
+// Eloquent Model 前提の Laravel preset の検査対象から外す。
+arch()->preset()->laravel()->ignoring('App\Models\Gateway');

--- a/src/tests/Arch/RequestValidationTest.php
+++ b/src/tests/Arch/RequestValidationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+// .claude/rules/laravel/form-request-validation.md:
+// Controller で $request->validate() / request()->validate() を使わず、
+// ルールは Form Request の rules() に置く。Validator ファサードの参照禁止だけでは
+// これらの呼び出しを検出できないため、トークン列から直接見つける。
+
+/**
+ * @return list<string>
+ */
+function controllerSources(): array
+{
+    $directory = new RecursiveDirectoryIterator(app_path('Http/Controllers'));
+    $files = [];
+
+    foreach (new RecursiveIteratorIterator($directory) as $file) {
+        if ($file->isFile() && $file->getExtension() === 'php') {
+            $files[] = $file->getPathname();
+        }
+    }
+
+    return $files;
+}
+
+/**
+ * `$request->validate(...)` と `request()->validate(...)` を検出する。
+ * コメントや文字列リテラルを除いたトークン列で判定するため、
+ * `Auth::guard()->validate(...)` のような別オブジェクトの validate は対象外。
+ *
+ * @return list<string>
+ */
+function validateCallsIn(string $code): array
+{
+    $accessors = [T_OBJECT_OPERATOR, T_NULLSAFE_OBJECT_OPERATOR];
+    $methods = ['validate', 'validateWithBag'];
+    $ignored = [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT, T_CONSTANT_ENCAPSED_STRING];
+
+    $tokens = array_values(array_filter(
+        token_get_all($code),
+        fn (array|string $token): bool => is_string($token) || ! in_array($token[0], $ignored, true),
+    ));
+
+    $found = [];
+
+    foreach ($tokens as $index => $token) {
+        if (! is_array($token) || ! in_array($token[0], $accessors, true)) {
+            continue;
+        }
+
+        $method = $tokens[$index + 1] ?? null;
+
+        if (! is_array($method) || $method[0] !== T_STRING || ! in_array($method[1], $methods, true)) {
+            continue;
+        }
+
+        $previous = $tokens[$index - 1] ?? null;
+
+        // $request->validate(...)
+        if (is_array($previous) && $previous[0] === T_VARIABLE && $previous[1] === '$request') {
+            $found[] = '$request->'.$method[1].'()';
+
+            continue;
+        }
+
+        // request()->validate(...)
+        $helper = $tokens[$index - 3] ?? null;
+
+        if (
+            $previous === ')'
+            && ($tokens[$index - 2] ?? null) === '('
+            && is_array($helper)
+            && $helper[0] === T_STRING
+            && $helper[1] === 'request'
+        ) {
+            $found[] = 'request()->'.$method[1].'()';
+        }
+    }
+
+    return $found;
+}
+
+it('Controller で $request->validate() を使わない', function () {
+    $violations = [];
+
+    foreach (controllerSources() as $file) {
+        foreach (validateCallsIn((string) file_get_contents($file)) as $call) {
+            $violations[] = basename($file).': '.$call;
+        }
+    }
+
+    expect($violations)->toBe([]);
+});

--- a/src/tests/Arch/RequestValidationTest.php
+++ b/src/tests/Arch/RequestValidationTest.php
@@ -34,7 +34,9 @@ function controllerSources(): array
 function validateCallsIn(string $code): array
 {
     $accessors = [T_OBJECT_OPERATOR, T_NULLSAFE_OBJECT_OPERATOR];
-    $methods = ['validate', 'validateWithBag'];
+    // PHP のメソッド名と関数名は大文字小文字を区別しないため、小文字で比較する。
+    $methods = ['validate', 'validatewithbag'];
+    $names = [T_STRING, T_NAME_FULLY_QUALIFIED];
     $ignored = [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT, T_CONSTANT_ENCAPSED_STRING];
 
     $tokens = array_values(array_filter(
@@ -51,28 +53,32 @@ function validateCallsIn(string $code): array
 
         $method = $tokens[$index + 1] ?? null;
 
-        if (! is_array($method) || $method[0] !== T_STRING || ! in_array($method[1], $methods, true)) {
+        if (! is_array($method) || $method[0] !== T_STRING) {
+            continue;
+        }
+
+        if (! in_array(strtolower($method[1]), $methods, true)) {
             continue;
         }
 
         $previous = $tokens[$index - 1] ?? null;
 
-        // $request->validate(...)
+        // $request->validate(...) （変数名は大文字小文字を区別する）
         if (is_array($previous) && $previous[0] === T_VARIABLE && $previous[1] === '$request') {
             $found[] = '$request->'.$method[1].'()';
 
             continue;
         }
 
-        // request()->validate(...)
+        // request()->validate(...) （\request() も対象にする）
         $helper = $tokens[$index - 3] ?? null;
 
         if (
             $previous === ')'
             && ($tokens[$index - 2] ?? null) === '('
             && is_array($helper)
-            && $helper[0] === T_STRING
-            && $helper[1] === 'request'
+            && in_array($helper[0], $names, true)
+            && strtolower(ltrim($helper[1], '\\')) === 'request'
         ) {
             $found[] = 'request()->'.$method[1].'()';
         }

--- a/src/tests/Pest.php
+++ b/src/tests/Pest.php
@@ -17,7 +17,7 @@ use Tests\TestCase;
 
 pest()->extend(TestCase::class)
  // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->in('Feature', 'Unit');
+    ->in('Feature', 'Unit', 'Arch');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`.claude/rules/**` に文書化してある設計ルールのうち機械判定できるものを Pest arch テストに落とし、CI で落ちるようにした。これまで規約は文書だけで、実際に強制しているものが何もなかった。

## 変更点

- `src/tests/Arch/PresetsTest.php`: Pest の `php` / `security` / `laravel` preset
- `src/tests/Arch/LayerBoundariesTest.php`: `model-layer-boundaries.md` と `form-request-validation.md` の Controller 側ルール
  - Service / Action レイヤーを作らない（ディレクトリ不在 + `Service` 接尾辞なし）
  - Eloquent Model は Eloquent の `Model` を継承し、外部 API（`Http` ファサード）を呼ばない
  - Gateway Model は `App\Models\Gateway\Model` を継承し、`Model` / `DB` を使わない
  - `App\Models\Concerns` は Trait である
  - Controller は `Validator` ファサードと `DB` ファサードを直接使わない
- `src/tests/Arch/RequestValidationTest.php`: Controller での `$request->validate()` / `request()->validate()` 禁止
- `src/tests/Arch/CodingStandardsTest.php`: `php.md` の strict types（`app/` と `tests/` の両方）
- `src/tests/Arch/PrecognitionTest.php`: Form Request を型指定した変更系 route に `HandlePrecognitiveRequests` が付いているか
- `src/phpunit.xml`: `Arch` testsuite を追加（`php artisan test` に含まれる。単独実行は `--testsuite=Arch`）
- `src/tests/Pest.php`: `Arch` ディレクトリにも `TestCase` をバインド（route 検査でアプリを起動するため）
- `.claude/rules/testing/architecture-tests.md`: 新規。arch テストの構成、書き方、規約追加時の運用、BDD フロー対象外である点
- `.claude/rules/testing/feature-test-policy.md`: 種類別テーブルに Arch テストの行を追加
- `CLAUDE.md`: Development Rules に上記規約への参照を追加

## Precognition の検査について

`form-request-validation.md` には「Form Request を使う変更系 route には `HandlePrecognitiveRequests` を付ける」というルールがあり、現状の `routes/auth.php` と `routes/web.php` は満たしている。ただしこれが漏れると、フロントの `onBlur` の `validate('field')` がライブ検証ではなく本処理（ログインやプロフィール更新）を実行してしまう。静かに壊れる種類の間違いなので、route 定義とコントローラのシグネチャから機械的に検証するテストを入れた。

route を走査して「アクション引数に FormRequest サブクラスを型指定している POST / PUT / PATCH / DELETE」を対象にし、middleware に `HandlePrecognitiveRequests` があるか確認する。controller action とクロージャ route の両方を対象にし、対象が 0 件になった場合も検査が空回りしないよう `$checked > 0` を確認している。

## `$request->validate()` の検査について

`Validator` ファサードの参照禁止だけでは、`Request $request` を受けて `$request->validate([...])` を呼ぶ経路が素通りしてしまう。しかもその route は Form Request を使わないので Precognition 検査の対象にもならず、2 つの規約を同時に回避できる状態だった。

そこで `token_get_all()` のトークン列で `$request->validate()` / `request()->validate()`（および `validateWithBag`）を検出する。正規表現ではなくトークン列にしたのは、コメントや文字列リテラル中の記述を誤検出しないためで、規約が明示している例外（`Auth::guard()->validate([...])`）も対象外になる。PHP のメソッド名と関数名は大文字小文字を区別しないため、`$request->Validate()` や `\request()->validate()` も検出できるよう正規化して比較している。

## laravel preset の調整

`arch()->preset()->laravel()` は `App\Models` 配下のクラスが Eloquent の `Model` を継承していることと、`Model` 接尾辞を持たないことを要求する。このリポジトリの `App\Models\Gateway\Model` は DB 永続化しない外部接続レイヤーの基底クラスで、どちらにも該当しない。意図的な設計なので `->ignoring('App\Models\Gateway')` で対象外にした。

## 検証

- `php artisan test`: 58 passed (158 assertions)。うち arch が 16 件
- `php artisan test --testsuite=Arch`: 16 passed、実行時間 0.36s
- `./vendor/bin/pint --test`: pass
- `./vendor/bin/phpstan analyse`: no errors

**ガードレールが実際に落ちることの確認**（いずれも確認後に元へ戻した）

- `app/Services/ReportService.php` を追加 → 「Service / Action レイヤーを作らない」と「Service 接尾辞のクラスを作らない」が失敗
- `Http` ファサードを使う Eloquent Model を追加 → 「Eloquent Model から外部 API を呼ばない」が失敗
- `declare(strict_types=1)` のないファイルを追加 → 「アプリケーションコードは strict types を宣言する」が失敗
- `routes/web.php` の `profile.update` から `HandlePrecognitiveRequests` を外す → Precognition 検査が失敗し、`PATCH /profile` を名指しで報告
- Form Request を引数に取るクロージャ route を middleware なしで追加 → Precognition 検査が失敗し、`POST /probe` を報告
- `$request->Validate()`（大文字混じり）、`\request()->validate()`（完全修飾）、`$request->validateWithBag()` を呼ぶ Controller を追加 → 3 件とも検出。同じファイル内の `Auth::guard()->validate()` と文字列リテラル `'$request->validate([])'` は誤検出されないことも確認

## 補足

CI 側の変更は不要。`.github/workflows/ci.yml` の Tests ジョブが `php artisan test` を実行しており、Arch testsuite もそこに含まれる。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3b537c0-b162-407c-9d37-e626ccdb0b82?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3b537c0-b162-407c-9d37-e626ccdb0b82&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * アーキテクチャテストを追加し、厳密な型宣言、レイヤー境界、設計ルールを自動検証できるようにしました。
  * Controllerでの直接的な入力検証やデータベース利用がないことを検証します。
  * 変更系ルートの必要なミドルウェア設定を確認します。
  * アーキテクチャテストを通常のテスト実行対象に含めました。

* **ドキュメント**
  * アーキテクチャテストの目的、実行方法、記述ルール、規約追加時の対応方針を文書化しました。
  * 設計ルールをテストで強制する開発方針を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->