### PR TITLE
Dependabot で依存更新を自動化する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+version: 2
+
+updates:
+  # PHP 依存。minor / patch はまとめて 1 PR、major は個別 PR にして影響範囲を見て判断する。
+  - package-ecosystem: composer
+    directory: /src
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(composer)"
+    groups:
+      composer-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # フロント依存。React 19 への major 更新は React Compiler の target 変更を伴うため、
+  # まとめずに個別 PR で来るようにしておく。
+  - package-ecosystem: npm
+    directory: /src
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(npm)"
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    commit-message:
+      prefix: "chore(actions)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Dockerfile のベースイメージ。
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    commit-message:
+      prefix: "chore(docker)"
+
+  # docker-compose.yml のサービスイメージ（postgres / redis / nginx）。
+  # Dockerfile とは別 ecosystem なので個別に定義する。
+  - package-ecosystem: docker-compose
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    commit-message:
+      prefix: "chore(docker)"
+    groups:
+      docker-compose:
+        patterns:
+          - "*"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

依存更新の自動化が一切なかったため、`.github/dependabot.yml` を追加した。テンプレートとして配布する前提だと、固定されたバージョンが古くなっていくのが一番静かに効く劣化なので、更新 PR が自動で来る状態にしておく。

現状すでに Tailwind 3 系（4 が現行）、Biome 1.5.3（2 系が現行）、`@types/react` 18 系などが据え置きになっている。

## 監視対象

| ecosystem | ディレクトリ | 対象ファイル |
| --- | --- | --- |
| `composer` | `/src` | `composer.json` / `composer.lock` |
| `npm` | `/src` | `package.json` / `package-lock.json` |
| `github-actions` | `/` | `.github/workflows/ci.yml` |
| `docker` | `/` | `Dockerfile`（ベースイメージ） |
| `docker-compose` | `/` | `docker-compose.yml`（postgres / redis / nginx） |

`docker` と `docker-compose` は Dependabot 上で別 ecosystem なので個別に定義している（Docker Compose 対応は 2025-02 に GA）。

## PR 数を抑える方針

- スケジュールは週次（月曜 9:00 JST）
- minor と patch は ecosystem ごとにまとめて 1 PR
- major は個別 PR。特に npm 側は React 19 への更新が React Compiler の `target` 変更を伴うため、他の更新と混ぜずに単独で判断できる形にしている
- `open-pull-requests-limit` は composer / npm を 5 に設定

ラベル指定は入れていない。このリポジトリにはまだラベルが定義されておらず、存在しないラベルを指定すると Dependabot 側がエラーになるため。

## 検証

`.github/dependabot.yml` を SchemaStore の公式スキーマ（GitHub Dependabot v2 config）で検証し、エラーなしを確認した。`package-ecosystem` として `docker-compose` が受理されることもこの検証で確認できている。

設定した各ディレクトリにマニフェストが実在することも確認した（`/src/composer.json`、`/src/package.json`、`/Dockerfile`、`/docker-compose.yml`、`/.github/workflows/`）。

実際の PR 生成はマージ後に Dependabot が動いて初めて確認できるため、そこは検証範囲外。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3b537c0-b162-407c-9d37-e626ccdb0b82?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3b537c0-b162-407c-9d37-e626ccdb0b82&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

