### PR TITLE
ci: PR は PHP 8.4 のみで回し、両バージョン互換は main push で検証する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3, 8.4]
+        # PR は本命の 8.4 だけで回し、テンプレートが約束する両バージョン互換は
+        # main への push (マージ時) で検証する (Actions 消費の削減。PR 時点の
+        # 8.3 退行はマージ後の main CI で検知される)。
+        php: ${{ github.event_name == 'pull_request' && fromJSON('["8.4"]') || fromJSON('["8.3", "8.4"]') }}
 
     name: Lint (PHP ${{ matrix.php }})
 
@@ -124,7 +127,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3, 8.4]
+        # PR は本命の 8.4 だけで回し、テンプレートが約束する両バージョン互換は
+        # main への push (マージ時) で検証する (Actions 消費の削減。PR 時点の
+        # 8.3 退行はマージ後の main CI で検知される)。
+        php: ${{ github.event_name == 'pull_request' && fromJSON('["8.4"]') || fromJSON('["8.3", "8.4"]') }}
 
     name: Tests (PHP ${{ matrix.php }})
 


### PR DESCRIPTION
## 概要

GitHub Actions の 8 月消費はこのリポジトリで **765 分 (CI 52 run、うち PR 44 = 大半が dependabot)**。lint / tests が PR ごとに PHP 8.3 / 8.4 の matrix で二重実行されていたのを、**PR は 8.4 のみ / main push は両バージョン**に変える。

## 判断

- テンプレートとして「8.3 / 8.4 両対応」を約束するのは維持する。検証が消えるのではなく、**マージ時 (main push) に寄る**
- トレードオフ: PR 時点では 8.3 の退行に気づけず、マージ後の main CI で初めて赤くなる。テンプレートはデプロイが無く main が赤でも実害が出ないため、修正 PR で直せばよい
- dependabot の設定 (minor/patch の週次グルーピング) は既に適切なので触っていない

## 変更

matrix を event で出し分け:

```yaml
php: ${{ github.event_name == 'pull_request' && fromJSON('["8.4"]') || fromJSON('["8.3", "8.4"]') }}
```

- 効果: PR 1 本あたり課金 ~2〜3 分削減 × 44 PR run/月
- concurrency (cancel-in-progress) は既存のまま

## テスト内容・方法

- `yaml.safe_load` で構文 OK。ジョブ構成 (lint / frontend / tests / e2e) は不変
- この PR の CI で「PR = Lint (PHP 8.4) / Tests (PHP 8.4) の各 1 ジョブだけが走り、8.3 が現れない」ことをもって PR 側の出し分けを検証する。push 側 (両バージョン) はマージ後の main CI で確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)