### PR TITLE
chore(dependabot): toolchain の major を無視して PR の再堆積を止める

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
 
   # フロント依存。React 19 への major 更新は React Compiler の target 変更を伴うため、
   # まとめずに個別 PR で来るようにしておく。
+  # Vite 8 / plugin-react 6 / TypeScript 7 は toolchain の専用作業にする。
+  # Dependabot の単独 major PR は CI が落ちるか、緑でも方針判断が必要なので無視する。
   - package-ecosystem: npm
     directory: /src
     schedule:
@@ -32,6 +34,13 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(npm)"
+    ignore:
+      - dependency-name: vite
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitejs/plugin-react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-and-patch:
         patterns:
@@ -55,6 +64,7 @@ updates:
           - "*"
 
   # Dockerfile のベースイメージ。
+  # テンプレートの約束は PHP 8.3 / 8.4。8.5 への major は CI matrix / 方針の専用作業。
   - package-ecosystem: docker
     directory: /
     schedule:
@@ -64,9 +74,13 @@ updates:
       timezone: Asia/Tokyo
     commit-message:
       prefix: "chore(docker)"
+    ignore:
+      - dependency-name: php
+        update-types: ["version-update:semver-major"]
 
   # docker-compose.yml のサービスイメージ（postgres / redis / nginx）。
   # Dockerfile とは別 ecosystem なので個別に定義する。
+  # Postgres 18 は既存 volume 非互換で、CI の service container もまだ 16。
   - package-ecosystem: docker-compose
     directory: /
     schedule:
@@ -76,6 +90,9 @@ updates:
       timezone: Asia/Tokyo
     commit-message:
       prefix: "chore(docker)"
+    ignore:
+      - dependency-name: postgres
+        update-types: ["version-update:semver-major"]
     groups:
       docker-compose:
         patterns:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

オープン PR が 9 本溜まっていたうち、Dependabot の **major 単独 PR** が半分以上でした。今回閉じた major が翌月曜にまた開かないよう、`dependabot.yml` に ignore を足します。

## 無視する major

- `vite` / `@vitejs/plugin-react` / `typescript` — toolchain 専用作業（Vite 8 は CI 赤、TS 7 は 2 世代飛ばし）
- `php` Docker イメージ — テンプレートの約束は 8.3 / 8.4（#44）
- `postgres` — 既存 volume 非互換。CI の service container もまだ 16

minor / patch の週次グループはそのままです。

## 同時に片付けた PR

- マージ: #44（CI 課金削減）, #43（npm minor/patch）, #36（composer minor/patch）
- rebase 待ち: #42（Actions v7。#44 のあとに載せ直し済み、CI 待ち）
- クローズ: #40 Vite 8, #39 plugin-react 6, #38 TypeScript 7, #35 Postgres 18, #34 PHP 8.5

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13afad2d-e9a8-4a2f-86dc-6326d82489bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13afad2d-e9a8-4a2f-86dc-6326d82489bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定**
  * Vite、Reactプラグイン、TypeScript、PHP、Postgresに関するmajorバージョン更新を、自動更新の対象外に設定しました。
  * npm、Docker、Docker Composeの更新に適用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->