### PR TITLE
feat: Rector 導入と PHP 8.5 を Docker/CI の本命にする

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -7,9 +7,8 @@
 1. `git status` と `git diff` で変更内容を確認
 2. **品質ゲート (MANDATORY)**: Lintを実行して全てパスすること
    ```bash
-   # PHP (Pint + PHPStan) - srcディレクトリ内で実行
-   cd src && composer pint
-   cd src && composer stan
+   # PHP (Pint + PHPStan + Rector) - srcディレクトリ内で実行
+   cd src && composer lint
 
    # TypeScript/React (Biome)
    cd src && npm run lint:js

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -24,7 +24,7 @@ Task(
   subagent_type: "quality-engineer",
   description: "Backend verification",
   prompt: "Verify Laravel backend:
-    1. Run: composer lint (Pint + PHPStan)
+    1. Run: composer lint (Pint + PHPStan + Rector)
     2. Run: composer test (Pest)
     3. Report: lint errors, test failures, coverage stats
     4. Fix auto-fixable issues with: composer pint",
@@ -68,9 +68,10 @@ TaskOutputで両方の結果を取得し、統合レポートを生成。
 
 ### Backend (Laravel/PHP)
 ```bash
-composer lint      # Pint + PHPStan
+composer lint      # Pint + PHPStan + Rector dry-run
 composer pint      # コードフォーマット
 composer stan      # 静的解析
+composer rector    # Rector dry-run
 composer test      # Pest テスト
 ```
 

--- a/.claude/rules/laravel/rector.md
+++ b/.claude/rules/laravel/rector.md
@@ -1,0 +1,44 @@
+---
+globs: ["src/app/**/*.php","src/bootstrap/app.php","src/config/**/*.php","src/database/**/*.php","src/routes/**/*.php","src/tests/**/*.php","src/rector.php"]
+---
+
+# Rector 自動リファクタ
+
+PHP の構文アップグレードと Laravel 向けリファクタは Rector で行う。フォーマットは Pint、静的解析は Larastan に任せ、Rector は AST 変換だけを担当する。
+
+## トリガー条件
+
+- `app/**/*.php`, `bootstrap/app.php`, `config/**/*.php`, `database/**/*.php`, `routes/**/*.php`, `tests/**/*.php` を編集・作成した時
+- `rector.php` を変更した時
+
+## 実行コマンド
+
+```bash
+# 変更確認（CI と同じ。コードは書き換えない）
+./vendor/bin/rector process --dry-run
+
+# 適用
+./vendor/bin/rector process
+```
+
+Composer スクリプト:
+
+```bash
+composer rector      # dry-run
+composer rector:fix  # 適用
+```
+
+## 方針
+
+- `phpVersion` は PHP 8.3（composer / Laravel 13 の下限）。`withPhpSets(php83: true)` も 8.3 まで。Docker / CI 本命の 8.5 専用構文は入れない
+- Laravel ルールは `withComposerBased(laravel: true)` で installed バージョンに合わせる
+- `LongArrayToShortArrayRector` は Pint と重複するので skip する
+- CI は `--dry-run` のみ。自動書き換えはしない
+- 新しいセット（deadCode / codeQuality / typeDeclarations など）を足すときは、先に dry-run の差分を見てからにする
+
+## 注意
+
+- Docker 環境: `docker compose exec app ./vendor/bin/rector process --dry-run`
+- 設定ファイル: `src/rector.php`
+- dry-run が失敗したら、安全な差分は `rector:fix` で適用するか、ノイズになるルールを `withSkip()` する
+- Pint の後に Rector を走らせるとフォーマットが崩れることがある。適用後は `composer pint` を再実行する

--- a/.claude/rules/php.md
+++ b/.claude/rules/php.md
@@ -35,6 +35,17 @@ PHPStan Level 5 + Larastan。
 
 **設定**: `phpstan.neon` → `level: 5`
 
+## 自動リファクタ
+
+Rector（PHP 8.3 + Laravel composer-based）。フォーマットは Pint に任せる。
+
+```bash
+./vendor/bin/rector process --dry-run  # 変更確認（CI と同じ）
+./vendor/bin/rector process            # 適用
+```
+
+**設定**: `rector.php` → `withPhpSets(php83: true)` / `PhpVersion::PHP_83`
+
 ## 型宣言
 
 - 引数の型宣言: 必須
@@ -76,5 +87,5 @@ php artisan ide-helper:models -W  # モデルの DocBlock を更新
 
 ```bash
 # コード品質チェック（CI/プッシュ前に実行）
-./vendor/bin/pint --test && ./vendor/bin/phpstan analyse
+./vendor/bin/pint --test && ./vendor/bin/phpstan analyse && ./vendor/bin/rector process --dry-run
 ```

--- a/.claude/skills/backend-guidelines/SKILL.md
+++ b/.claude/skills/backend-guidelines/SKILL.md
@@ -462,9 +462,10 @@ php artisan ide-helper:models -W
 ### コード品質
 ```bash
 # PHP
-composer lint          # Pint + PHPStan
-composer pint          # フォーマットチェック
+composer lint          # Pint + PHPStan + Rector dry-run
+composer pint          # フォーマット
 composer stan          # 静的解析
+composer rector        # Rector dry-run
 composer test          # Pest テスト
 
 # TypeScript

--- a/.claude/skills/tdd-methodology/SKILL.md
+++ b/.claude/skills/tdd-methodology/SKILL.md
@@ -806,7 +806,7 @@ This skill works with `/kiro:spec-impl`:
 
 ```bash
 # Full verification
-composer lint      # Pint + PHPStan
+composer lint      # Pint + PHPStan + Rector dry-run
 composer test      # Pest tests
 npm run lint       # Biome + ESLint
 npm run test       # Vitest tests

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,7 +64,8 @@ updates:
           - "*"
 
   # Dockerfile のベースイメージ。
-  # テンプレートの約束は PHP 8.3 / 8.4。8.5 への major は CI matrix / 方針の専用作業。
+  # テンプレートの本命は PHP 8.5。composer 下限は Laravel 13 に合わせて 8.3。
+  # 8.6 への major は CI matrix / 方針の専用作業。
   - package-ecosystem: docker
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # PR は本命の 8.4 だけで回し、テンプレートが約束する両バージョン互換は
-        # main への push (マージ時) で検証する (Actions 消費の削減。PR 時点の
-        # 8.3 退行はマージ後の main CI で検知される)。
-        php: ${{ github.event_name == 'pull_request' && fromJSON('["8.4"]') || fromJSON('["8.3", "8.4"]') }}
+        # PR は本命の 8.5 だけで回し、テンプレートが約束する両端互換
+        # （Laravel 13 の下限 8.3 と上限 8.5）は main への push で検証する。
+        # 8.4 は中間バージョンなので matrix から外し、Actions 消費を抑える。
+        php: ${{ github.event_name == 'pull_request' && fromJSON('["8.5"]') || fromJSON('["8.3", "8.5"]') }}
 
     name: Lint (PHP ${{ matrix.php }})
 
@@ -47,6 +47,9 @@ jobs:
 
     - name: Execute Larastan (Static Analysis)
       run: ./vendor/bin/phpstan analyse --memory-limit=2G
+
+    - name: Execute Rector (Dry Run)
+      run: ./vendor/bin/rector process --dry-run
 
   frontend:
     runs-on: ubuntu-latest
@@ -70,7 +73,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.4
+        php-version: 8.5
         extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
         coverage: none
 
@@ -127,10 +130,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # PR は本命の 8.4 だけで回し、テンプレートが約束する両バージョン互換は
-        # main への push (マージ時) で検証する (Actions 消費の削減。PR 時点の
-        # 8.3 退行はマージ後の main CI で検知される)。
-        php: ${{ github.event_name == 'pull_request' && fromJSON('["8.4"]') || fromJSON('["8.3", "8.4"]') }}
+        # PR は本命の 8.5 だけで回し、テンプレートが約束する両端互換
+        # （Laravel 13 の下限 8.3 と上限 8.5）は main への push で検証する。
+        # 8.4 は中間バージョンなので matrix から外し、Actions 消費を抑える。
+        php: ${{ github.event_name == 'pull_request' && fromJSON('["8.5"]') || fromJSON('["8.3", "8.5"]') }}
 
     name: Tests (PHP ${{ matrix.php }})
 
@@ -197,7 +200,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.4
+        php-version: 8.5
         extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
         coverage: none
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Kiro-style Spec Driven Development implementation on AI-DLC (AI Development Life
 - Service クラスは禁止し、DB 永続化は Eloquent Model、外部接続は Gateway Model、共通振る舞いは Concerns に置く。詳細は `.claude/rules/laravel/model-layer-boundaries.md` を参照
 - React 側は Inertia の Pages を入口として残し、feature 固有 UI / hooks / helpers は `features/{feature}` に置く。詳細は `.claude/rules/frontend/architecture.md` を参照
 - React Compiler をビルドに常時適用する。メモ化はコンパイラ任せにし、手書きの `useMemo` / `useCallback` / `memo` を既定にしない。詳細は `.claude/rules/frontend/react-compiler.md` を参照
+- PHP の自動リファクタは `.claude/rules/laravel/rector.md` に従い、Rector の `process --dry-run` を CI で実行する。適用時の PHP バージョンは 8.3（下限）に固定する
 - フロント品質ゲートは `.claude/rules/frontend/quality-scans.md` に従い、Biome / TypeScript / React Compiler 検査 / knip / jscpd / Vitest を CI で実行する
 - フロントのテストはコンポーネント / hook を Vitest、画面をまたぐフローを Playwright で書く。詳細は `.claude/rules/frontend/testing.md` を参照
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-fpm
+FROM php:8.5-fpm
 
 # Arguments defined in docker-compose.yml
 ARG user=laravel-user

--- a/src/app/Models/Eloquent/User.php
+++ b/src/app/Models/Eloquent/User.php
@@ -6,35 +6,25 @@ namespace App\Models\Eloquent;
 
 use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
+#[Fillable([
+    'name',
+    'email',
+    'password',
+])]
+#[Hidden([
+    'password',
+    'remember_token',
+])]
 class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'name',
-        'email',
-        'password',
-    ];
-
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var list<string>
-     */
-    protected $hidden = [
-        'password',
-        'remember_token',
-    ];
 
     /**
      * Get the attributes that should be cast.

--- a/src/composer.json
+++ b/src/composer.json
@@ -16,6 +16,7 @@
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^3.6",
+        "driftingly/rector-laravel": "^2.5",
         "fakerphp/faker": "^1.23",
         "larastan/larastan": "^3.0",
         "laravel/boost": "^2.0",
@@ -25,6 +26,7 @@
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
         "pestphp/pest": "^4.0",
+        "rector/rector": "^2.6",
         "spatie/laravel-typescript-transformer": "^2.5"
     },
     "autoload": {
@@ -56,6 +58,15 @@
         "dev": [
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+        ],
+        "pint": ["@php vendor/bin/pint --ansi"],
+        "stan": ["@php vendor/bin/phpstan analyse --memory-limit=2G --ansi"],
+        "rector": ["@php vendor/bin/rector process --dry-run --ansi"],
+        "rector:fix": ["@php vendor/bin/rector process --ansi"],
+        "lint": [
+            "@php vendor/bin/pint --test --ansi",
+            "@stan",
+            "@rector"
         ],
         "test": ["@php artisan config:clear --ansi", "@php artisan test"]
     },

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "39bcc82a0919e2b101c987cc0d9fb344",
+    "content-hash": "863688c84e4c93310cedb54985ef6209",
     "packages": [
         {
             "name": "brick/math",
@@ -7369,6 +7369,42 @@
             "time": "2025-08-20T19:15:30+00:00"
         },
         {
+            "name": "driftingly/rector-laravel",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/driftingly/rector-laravel.git",
+                "reference": "0dbdd842dfdbc821cfe5f47ca7326e2502b2a107"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/driftingly/rector-laravel/zipball/0dbdd842dfdbc821cfe5f47ca7326e2502b2a107",
+                "reference": "0dbdd842dfdbc821cfe5f47ca7326e2502b2a107",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "rector/rector": "^2.2.7",
+                "webmozart/assert": "^1.11 || ^2.0"
+            },
+            "type": "rector-extension",
+            "autoload": {
+                "psr-4": {
+                    "RectorLaravel\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Rector upgrades rules for Laravel Framework",
+            "support": {
+                "issues": "https://github.com/driftingly/rector-laravel/issues",
+                "source": "https://github.com/driftingly/rector-laravel/tree/2.5.0"
+            },
+            "time": "2026-06-02T16:22:14+00:00"
+        },
+        {
             "name": "fakerphp/faker",
             "version": "v1.24.1",
             "source": {
@@ -9483,6 +9519,66 @@
             "time": "2026-02-16T08:34:36+00:00"
         },
         {
+            "name": "rector/rector",
+            "version": "2.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.2.6"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-18T22:01:18+00:00"
+        },
+        {
             "name": "sebastian/cli-parser",
             "version": "4.2.0",
             "source": {
@@ -10771,12 +10867,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/src/rector.php
+++ b/src/rector.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
+use Rector\ValueObject\PhpVersion;
+use RectorLaravel\Set\LaravelSetProvider;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__.'/app',
+        __DIR__.'/bootstrap/app.php',
+        __DIR__.'/config',
+        __DIR__.'/database',
+        __DIR__.'/routes',
+        __DIR__.'/tests',
+    ])
+    ->withSkip([
+        __DIR__.'/bootstrap/cache',
+        __DIR__.'/storage',
+        __DIR__.'/vendor',
+        // Pint が array() → [] を扱う。Rector と二重適用しない。
+        LongArrayToShortArrayRector::class,
+    ])
+    // composer / Laravel 13 の下限は PHP 8.3。Docker / CI 本命の 8.5 専用構文は入れない。
+    ->withPhpSets(php83: true)
+    ->withPhpVersion(PhpVersion::PHP_83)
+    ->withSetProviders(LaravelSetProvider::class)
+    ->withComposerBased(laravel: true);

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -8,18 +8,14 @@ use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
-Route::get('/', function () {
-    return Inertia::render('Welcome', [
-        'canLogin' => Route::has('login'),
-        'canRegister' => Route::has('register'),
-        'laravelVersion' => Application::VERSION,
-        'phpVersion' => PHP_VERSION,
-    ]);
-});
+Route::get('/', fn () => Inertia::render('Welcome', [
+    'canLogin' => Route::has('login'),
+    'canRegister' => Route::has('register'),
+    'laravelVersion' => Application::VERSION,
+    'phpVersion' => PHP_VERSION,
+]));
 
-Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/src/tests/Arch/LayerBoundariesTest.php
+++ b/src/tests/Arch/LayerBoundariesTest.php
@@ -29,8 +29,8 @@ arch('Eloquent Model から外部 API を呼ばない')
 arch('Gateway Model は Gateway の基底クラスを継承する')
     ->expect('App\Models\Gateway')
     ->classes()
-    ->toExtend('App\Models\Gateway\Model')
-    ->ignoring('App\Models\Gateway\Model');
+    ->toExtend(App\Models\Gateway\Model::class)
+    ->ignoring(App\Models\Gateway\Model::class);
 
 arch('Gateway Model は DB 永続化しない')
     ->expect('App\Models\Gateway')

--- a/src/tests/Feature/Auth/AuthGwtTest.php
+++ b/src/tests/Feature/Auth/AuthGwtTest.php
@@ -20,17 +20,13 @@ uses(RefreshDatabase::class);
 describe('UC-01: ユーザー登録', function () {
     it('Scenario 1.1: 有効なデータで新規ユーザーを登録できる', function () {
         scenario('新規ユーザー登録フロー')
-            ->given('有効なユーザーデータ（名前、メール、パスワード）', function () {
-                return [
-                    'name' => 'Test User',
-                    'email' => 'test@example.com',
-                    'password' => 'password',
-                    'password_confirmation' => 'password',
-                ];
-            })
-            ->when('登録APIを呼び出す', function (array $userData) {
-                return $this->post('/register', $userData);
-            })
+            ->given('有効なユーザーデータ（名前、メール、パスワード）', fn () => [
+                'name' => 'Test User',
+                'email' => 'test@example.com',
+                'password' => 'password',
+                'password_confirmation' => 'password',
+            ])
+            ->when('登録APIを呼び出す', fn (array $userData) => $this->post('/register', $userData))
             ->then('ユーザーが作成される', function ($response) {
                 expect(User::where('email', 'test@example.com')->exists())->toBeTrue();
             })
@@ -55,9 +51,7 @@ describe('UC-01: ユーザー登録', function () {
                     'password_confirmation' => 'password',
                 ];
             })
-            ->when('登録APIを呼び出す', function (array $userData) {
-                return $this->post('/register', $userData);
-            })
+            ->when('登録APIを呼び出す', fn (array $userData) => $this->post('/register', $userData))
             ->then('バリデーションエラーになる', function ($response) {
                 $response->assertSessionHasErrors('email');
             })
@@ -75,24 +69,18 @@ describe('UC-01: ユーザー登録', function () {
 describe('UC-02: ログイン', function () {
     it('Scenario 2.1: 正しい認証情報でログインできる', function () {
         scenario('正常ログインフロー')
-            ->given('登録済みユーザーが存在する', function () {
-                return User::factory()->create([
+            ->given('登録済みユーザーが存在する', fn () => User::factory()->create([
+                'email' => 'user@example.com',
+                'password' => bcrypt('correct-password'),
+            ]))
+            ->and('正しいメールアドレスとパスワード', fn (User $user) => [
+                'user' => $user,
+                'credentials' => [
                     'email' => 'user@example.com',
-                    'password' => bcrypt('correct-password'),
-                ]);
-            })
-            ->and('正しいメールアドレスとパスワード', function (User $user) {
-                return [
-                    'user' => $user,
-                    'credentials' => [
-                        'email' => 'user@example.com',
-                        'password' => 'correct-password',
-                    ],
-                ];
-            })
-            ->when('ログインAPIを呼び出す', function (array $context) {
-                return $this->post('/login', $context['credentials']);
-            })
+                    'password' => 'correct-password',
+                ],
+            ])
+            ->when('ログインAPIを呼び出す', fn (array $context) => $this->post('/login', $context['credentials']))
             ->then('認証済み状態になる', function ($response) {
                 $this->assertAuthenticated();
             })
@@ -104,24 +92,18 @@ describe('UC-02: ログイン', function () {
 
     it('Scenario 2.2: 間違ったパスワードではログインできない', function () {
         scenario('パスワード誤りでログイン失敗')
-            ->given('登録済みユーザーが存在する', function () {
-                return User::factory()->create([
+            ->given('登録済みユーザーが存在する', fn () => User::factory()->create([
+                'email' => 'user@example.com',
+                'password' => bcrypt('correct-password'),
+            ]))
+            ->and('間違ったパスワード', fn (User $user) => [
+                'user' => $user,
+                'credentials' => [
                     'email' => 'user@example.com',
-                    'password' => bcrypt('correct-password'),
-                ]);
-            })
-            ->and('間違ったパスワード', function (User $user) {
-                return [
-                    'user' => $user,
-                    'credentials' => [
-                        'email' => 'user@example.com',
-                        'password' => 'wrong-password',
-                    ],
-                ];
-            })
-            ->when('ログインAPIを呼び出す', function (array $context) {
-                return $this->post('/login', $context['credentials']);
-            })
+                    'password' => 'wrong-password',
+                ],
+            ])
+            ->when('ログインAPIを呼び出す', fn (array $context) => $this->post('/login', $context['credentials']))
             ->then('ゲスト状態のまま', function ($response) {
                 $this->assertGuest();
             })
@@ -145,9 +127,7 @@ describe('UC-03: ログアウト', function () {
 
                 return $user;
             })
-            ->when('ログアウトAPIを呼び出す', function (User $user) {
-                return $this->post('/logout');
-            })
+            ->when('ログアウトAPIを呼び出す', fn (User $user) => $this->post('/logout'))
             ->then('ゲスト状態になる', function ($response) {
                 $this->assertGuest();
             })

--- a/src/tests/Pest.php
+++ b/src/tests/Pest.php
@@ -30,9 +30,7 @@ pest()->extend(TestCase::class)
 |
 */
 
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
-});
+expect()->extend('toBeOne', fn () => $this->toBe(1));
 
 /*
 |--------------------------------------------------------------------------

--- a/src/tests/Support/Gwt/Scenario.php
+++ b/src/tests/Support/Gwt/Scenario.php
@@ -20,8 +20,6 @@ use PHPUnit\Framework\Assert;
  */
 final class Scenario
 {
-    private string $description;
-
     /** @var array<int, array{description: string, action: Closure, result: mixed}> */
     private array $givens = [];
 
@@ -33,10 +31,7 @@ final class Scenario
 
     private mixed $context = null;
 
-    public function __construct(string $description)
-    {
-        $this->description = $description;
-    }
+    public function __construct(private readonly string $description) {}
 
     /**
      * Define a precondition or setup step.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 方針

Laravel は上げない。公式最新は **Laravel 13**（2026-03-17、bug fix は 2027 Q3 まで）。Laravel 14 はまだ無い。`laravel/framework: ^13.0` のまま patch は Dependabot に任せる。

PHP は **composer 下限 8.3 を残し、実行環境と PR CI だけ 8.5 にする**。

| 場所 | バージョン | 理由 |
| --- | --- | --- |
| `composer.json` `php` | `^8.3` | Laravel 13 の公式下限。fork 側を 8.5 強制しない |
| Rector `phpVersion` | PHP 8.3 | 下限向け構文だけ出す。8.5 専用構文を入れない |
| Dockerfile | `php:8.5-fpm` | テンプレートのデフォルト実行環境 |
| CI PR | 8.5 のみ | Actions 消費を抑える |
| CI main | 8.3 + 8.5 | Laravel 13 の両端を検証。8.4 は中間なので外す |

PHP 8.5.9 は 2025-11 リリースから 9 ヶ月経っており、Laravel 13 も 8.3–8.5 を公式サポートしている。以前閉じた Dependabot #34（8.3-fpm → 8.5-fpm）は CI / 約束が追いついていなかったのが理由で、今回それを揃えた。

## Rector

[Zenn の Rector 記事](https://zenn.dev/m01tyan/articles/3fcf6b59fba070) の 7.4→8.1 設定はコピーしていない。

- `rector/rector` + `driftingly/rector-laravel`
- 現行 API: `RectorConfig::configure()` / `withPhpSets(php83: true)` / `withComposerBased(laravel: true)`
- Pint と重複する `LongArrayToShortArrayRector` は skip
- CI は `rector process --dry-run`（自動書き換えしない）
- `composer lint` = Pint `--test` + Larastan + Rector dry-run

初回 dry-run で出た差分は適用済み（Fillable/Hidden attribute、arrow function、constructor promotion など）。Pint / Larastan / Rector dry-run はローカルで green。

## 検証

- ローカル: `pint --test` / `phpstan analyse` / `rector process --dry-run`
- ブラウザ確認は対象外（ツールチェーン変更）
- GitHub Actions の PHP 8.5 job をこの PR で確認する

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13afad2d-e9a8-4a2f-86dc-6326d82489bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13afad2d-e9a8-4a2f-86dc-6326d82489bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

