### PR TITLE
chore(dependabot): Node 22 前提の frontend major を無視する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,8 @@ updates:
 
   # フロント依存。React 19 への major 更新は React Compiler の target 変更を伴うため、
   # まとめずに個別 PR で来るようにしておく。
-  # Vite 8 / plugin-react 6 / TypeScript 7 は toolchain の専用作業にする。
-  # Dependabot の単独 major PR は CI が落ちるか、緑でも方針判断が必要なので無視する。
+  # Vite 8 / plugin-react 6 / TypeScript 7 / laravel-vite-plugin 3 は toolchain の専用作業。
+  # Babel 8 / jsdom 30 / concurrently 10 は Node 22+ 前提で、CI はまだ Node 20。
   - package-ecosystem: npm
     directory: /src
     schedule:
@@ -40,6 +40,14 @@ updates:
       - dependency-name: "@vitejs/plugin-react"
         update-types: ["version-update:semver-major"]
       - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
+      - dependency-name: laravel-vite-plugin
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: jsdom
+        update-types: ["version-update:semver-major"]
+      - dependency-name: concurrently
         update-types: ["version-update:semver-major"]
     groups:
       npm-minor-and-patch:


### PR DESCRIPTION
## 概要

オープン PR が 8 本残っていたので付けた。

## 今回マージした PR

- #46 mailpit v1.30 → v1.31（CI 緑）
- #47 laravel/wayfinder 0.1.16 → 0.1.21（CI 緑）
- #49 npm minor/patch グループ 6 件（CI 緑）

## 閉じた PR

CI は Node 20 のまま。次の major は Node 22+ か Vite 8 前提なので閉じました。

- #50 concurrently 9 → 10（Node <22 を切っている。#49 と lock 衝突）
- #51 @babel/core 7 → 8（Frontend Quality 赤）
- #52 jsdom 29 → 30（Node `^22.22.2` 以上。Frontend Quality 赤）
- #53 laravel-vite-plugin 2 → 3（peer が Vite 8。#40 / #45 と同じ専用作業）

## この PR

翌週に同じ major が開かないよう、`dependabot.yml` の npm ignore に足します。

## 残件

- #48 inertiajs/inertia-laravel 2 → 3 は rebase 済み。CI 再走中。緑ならマージします。