### PR TITLE
fix(claude): Claude Code hooks が一度も動いていなかった問題を修正

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -19,7 +19,7 @@
    docker compose exec app npm run lint:js
    ```
    - **Lint失敗時は絶対にコミットしない**
-   - 修正: `cd src && composer pint -- --fix` または `cd src && npm run lint:js:fix`
+   - 修正: `docker compose exec app composer pint` または `docker compose exec app npm run check`
 3. 変更の目的を分析（新機能、バグ修正、リファクタ等）
 4. Conventional Commits形式でメッセージを作成
 5. コミットを実行

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -35,11 +35,13 @@ Task(
   subagent_type: "quality-engineer",
   description: "Frontend verification",
   prompt: "Verify React frontend:
-    1. Run: npm run lint (Biome + ESLint)
+    1. Run: npm run lint:js (Biome)
     2. Run: npm run types (TypeScript check)
-    3. Run: npm run test (Vitest)
-    4. Report: lint errors, type errors, test failures
-    5. Fix auto-fixable issues",
+    3. Run: npm run lint:react-compiler (React Compiler)
+    4. Run: npm run lint:dead-code / npm run lint:duplication (knip / jscpd)
+    5. Run: npm run test:unit (Vitest)
+    6. Report: lint errors, type errors, test failures
+    7. Fix auto-fixable issues",
   run_in_background: true
 )
 ```
@@ -77,17 +79,21 @@ composer test      # Pest テスト
 
 ### Frontend (React/TypeScript)
 ```bash
-npm run lint       # Biome + ESLint
-npm run lint:js    # Biome のみ
-npm run types      # TypeScript 型チェック
-npm run test       # Vitest テスト
-npm run format     # Prettier フォーマット
+npm run lint:js               # Biome lint
+npm run types                 # TypeScript 型チェック
+npm run lint:react-compiler   # React Compiler 最適化スキップ検出
+npm run lint:dead-code        # knip
+npm run lint:duplication      # jscpd
+npm run test:unit             # Vitest
+npm run test:e2e              # Playwright E2E
+npm run format                # Biome フォーマット
 ```
 
 ### Full Stack
 ```bash
-composer dev       # 開発サーバー起動（Laravel + Vite + Queue）
-npm run lint:all   # JS + PHP 全体 lint
+composer dev            # 開発サーバー起動（Laravel + Vite + Queue）
+composer lint           # Pint + PHPStan + Rector (dry-run)
+npm run lint:architecture   # knip + jscpd
 ```
 
 ## カバレッジ基準

--- a/.claude/hooks/auto-format.sh
+++ b/.claude/hooks/auto-format.sh
@@ -1,39 +1,29 @@
 #!/bin/bash
-# Auto-format hook for PostToolUse (Edit/Write)
-# Formats PHP and TypeScript/JavaScript files automatically
+# PostToolUse hook: format edited files with Pint / Biome.
 
 set -e
 
-# Read tool input from stdin
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
-# Exit if no file path
-if [ -z "$FILE_PATH" ]; then
-  exit 0
-fi
+[ -z "$FILE_PATH" ] && exit 0
 
-# Get file extension
+# shellcheck source=lib-project.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib-project.sh"
+
 EXT="${FILE_PATH##*.}"
 
-# Get project root (where composer.json is)
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-
-# Format based on file type
 case "$EXT" in
   php)
-    # Format PHP with Laravel Pint
-    if [ -f "$PROJECT_ROOT/vendor/bin/pint" ]; then
-      "$PROJECT_ROOT/vendor/bin/pint" "$FILE_PATH" --quiet 2>/dev/null || true
+    if php_tooling_available; then
+      php_exec ./vendor/bin/pint "$(container_path "$FILE_PATH")" --quiet 2>/dev/null || true
     fi
     ;;
   ts|tsx|js|jsx)
-    # Format TypeScript/JavaScript with Biome
-    if [ -f "$PROJECT_ROOT/node_modules/.bin/biome" ]; then
-      "$PROJECT_ROOT/node_modules/.bin/biome" format --write "$FILE_PATH" 2>/dev/null || true
-    # Fallback to Prettier
-    elif [ -f "$PROJECT_ROOT/node_modules/.bin/prettier" ]; then
-      "$PROJECT_ROOT/node_modules/.bin/prettier" --write "$FILE_PATH" 2>/dev/null || true
+    if [ -x "$APP_DIR/node_modules/.bin/biome" ]; then
+      (cd "$APP_DIR" && ./node_modules/.bin/biome format --write "$FILE_PATH" 2>/dev/null) || true
+    elif [ -x "$APP_DIR/node_modules/.bin/prettier" ]; then
+      (cd "$APP_DIR" && ./node_modules/.bin/prettier --write "$FILE_PATH" 2>/dev/null) || true
     fi
     ;;
 esac

--- a/.claude/hooks/lib-project.sh
+++ b/.claude/hooks/lib-project.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Shared helpers for Claude Code hooks.
+#
+# Layout note: the Laravel app lives in src/, not at the repository root.
+# vendor/ and node_modules/ are under src/, and the host has no php binary,
+# so PHP tooling has to go through the app container (working_dir /var/www == ./src).
+
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+APP_DIR="$PROJECT_ROOT/src"
+COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yml"
+
+# Repository-relative path (src/app/Foo.php) from an absolute or relative path.
+repo_path() {
+  local path="$1"
+  printf '%s' "${path#"$PROJECT_ROOT"/}"
+}
+
+# Container-relative path (app/Foo.php) for a repo path under src/.
+container_path() {
+  local path
+  path="$(repo_path "$1")"
+  printf '%s' "${path#src/}"
+}
+
+# True when the app container is up and PHP tooling can be reached.
+php_tooling_available() {
+  command -v docker >/dev/null 2>&1 || return 1
+  [ -f "$COMPOSE_FILE" ] || return 1
+  docker compose -f "$COMPOSE_FILE" ps --status running --services 2>/dev/null | grep -qx app
+}
+
+# Run a command inside the app container from /var/www.
+php_exec() {
+  docker compose -f "$COMPOSE_FILE" exec -T app "$@"
+}

--- a/.claude/hooks/post-edit-check.sh
+++ b/.claude/hooks/post-edit-check.sh
@@ -1,74 +1,85 @@
 #!/bin/bash
-# Post-edit hook: lint only (tests run on commit)
-# Checks PHP and TypeScript files after editing
+# PostToolUse hook: architecture guards + per-file lint.
+#
+# Architecture violations exit 2 so the message is fed back to Claude.
+# Lint output is informational and never blocks (tests run on commit).
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 [ -z "$FILE_PATH" ] && exit 0
 
+# shellcheck source=lib-project.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib-project.sh"
+
+REPO_PATH="$(repo_path "$FILE_PATH")"
 EXT="${FILE_PATH##*.}"
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+VIOLATIONS=""
+
+add_violation() {
+  VIOLATIONS="${VIOLATIONS}$1
+"
+}
 
 case "$EXT" in
   php)
     # Service / Action classes become generic buckets; keep logic in Models.
-    if [[ "$FILE_PATH" == *"/app/Services/"* || "$FILE_PATH" == *"/app/Actions/"* ]]; then
-      echo "BLOCK: Service / Action classes are not allowed."
-      echo "Place DB logic in Eloquent Models, external API logic in Models/Gateway, and shared model behavior in Models/Concerns."
-    elif [[ "$FILE_PATH" == *Service.php && "$FILE_PATH" != *"/app/Providers/"*ServiceProvider.php ]]; then
-      echo "BLOCK: Service classes are not allowed."
-      echo "Place DB logic in Eloquent Models, external API logic in Models/Gateway, and shared model behavior in Models/Concerns."
+    if [[ "$REPO_PATH" == src/app/Services/* || "$REPO_PATH" == src/app/Actions/* ]]; then
+      add_violation "BLOCK: Service / Action classes are not allowed ($REPO_PATH).
+Place DB logic in Eloquent Models, external API logic in App\\Models\\Gateway, and shared model behavior in App\\Models\\Concerns."
+    elif [[ "$REPO_PATH" == src/app/*Service.php && "$REPO_PATH" != src/app/Providers/*ServiceProvider.php ]]; then
+      add_violation "BLOCK: Service classes are not allowed ($REPO_PATH).
+Place DB logic in Eloquent Models, external API logic in App\\Models\\Gateway, and shared model behavior in App\\Models\\Concerns."
     fi
 
     # Enforce Form Request based input validation in controllers.
-    if [[ "$FILE_PATH" == *"/app/Http/Controllers/"* ]]; then
-      if grep -nE '(\$request->validate\(|request\(\)->validate\()' "$FILE_PATH" >/tmp/form-request-validation-check.txt; then
-        echo "BLOCK: Controller input validation must use a Form Request object."
-        cat /tmp/form-request-validation-check.txt
-        echo "Move rules to app/Http/Requests/** and read validated data with \$request->validated()."
+    if [[ "$REPO_PATH" == src/app/Http/Controllers/* ]]; then
+      MATCHES=$(grep -nE '(\$request->validate\(|request\(\)->validate\()' "$FILE_PATH" || true)
+      if [ -n "$MATCHES" ]; then
+        add_violation "BLOCK: Controller input validation must use a Form Request object ($REPO_PATH).
+$MATCHES
+Move rules to app/Http/Requests/** and read validated data with \$request->validated()."
       fi
     fi
-
-    # Run PHPStan on the file
-    if [ -f "$PROJECT_ROOT/vendor/bin/phpstan" ]; then
-      echo "📋 Analyzing: $(basename "$FILE_PATH")"
-      "$PROJECT_ROOT/vendor/bin/phpstan" analyze "$FILE_PATH" --no-progress 2>&1 || true
-    fi
     ;;
-  ts|tsx)
-    if grep -nE '(:| as |<|,|\(|\[|\{|=)\s*any\b|Array<\s*any\s*>|Record<[^>]*,\s*any\s*>' "$FILE_PATH" >/tmp/type-safety-any-check.txt; then
-      echo "BLOCK: TypeScript any is not allowed."
-      cat /tmp/type-safety-any-check.txt
-      echo "Use generated Data types, precise local Props, unknown, or a generic type parameter instead."
+  ts|tsx|js|jsx)
+    MATCHES=$(grep -nE '(:| as |<|,|\(|\[|\{|=)\s*any\b|Array<\s*any\s*>|Record<[^>]*,\s*any\s*>' "$FILE_PATH" || true)
+    if [ -n "$MATCHES" ]; then
+      add_violation "BLOCK: TypeScript any is not allowed ($REPO_PATH).
+$MATCHES
+Use generated Data types, precise local Props, unknown, or a generic type parameter instead."
     fi
 
-    if [[ "$FILE_PATH" == *"/resources/js/types/"* && "$FILE_PATH" != *"/resources/js/types/generated.d.ts" && "$FILE_PATH" != *"/resources/js/types/vite-env.d.ts" ]]; then
-      if grep -nE '^\s*export\s+(interface|type)\s+' "$FILE_PATH" >/tmp/type-safety-manual-types-check.txt; then
-        echo "BLOCK: Manual exported types under resources/js/types are not allowed."
-        cat /tmp/type-safety-manual-types-check.txt
-        echo "Create app/Data/** with #[TypeScript], run php artisan typescript:transform, and use resources/js/types/generated.d.ts."
+    if [[ "$REPO_PATH" == src/resources/js/types/* \
+       && "$REPO_PATH" != src/resources/js/types/generated.d.ts \
+       && "$REPO_PATH" != src/resources/js/types/vite-env.d.ts ]]; then
+      MATCHES=$(grep -nE '^\s*export\s+(interface|type)\s+' "$FILE_PATH" || true)
+      if [ -n "$MATCHES" ]; then
+        add_violation "BLOCK: Manual exported types under resources/js/types are not allowed ($REPO_PATH).
+$MATCHES
+Create app/Data/** with #[TypeScript], run php artisan typescript:transform, and use resources/js/types/generated.d.ts."
       fi
     fi
+    ;;
+esac
 
-    # Run TypeScript check
-    if [ -f "$PROJECT_ROOT/node_modules/.bin/tsc" ]; then
-      echo "📋 Type checking: $(basename "$FILE_PATH")"
-      # Use tsc with --noEmit to just check types
-      cd "$PROJECT_ROOT" && npm run types 2>&1 | head -20 || true
+if [ -n "$VIOLATIONS" ]; then
+  printf '%s' "$VIOLATIONS" >&2
+  exit 2
+fi
+
+# Informational lint. Never blocks; full type check and tests run on commit.
+case "$EXT" in
+  php)
+    if php_tooling_available; then
+      echo "Analyzing: $(basename "$FILE_PATH")"
+      php_exec ./vendor/bin/phpstan analyse "$(container_path "$FILE_PATH")" --no-progress 2>&1 || true
     fi
     ;;
-  js|jsx)
-    if grep -nE '(:| as |<|,|\(|\[|\{|=)\s*any\b|Array<\s*any\s*>|Record<[^>]*,\s*any\s*>' "$FILE_PATH" >/tmp/type-safety-any-check.txt; then
-      echo "BLOCK: TypeScript any is not allowed."
-      cat /tmp/type-safety-any-check.txt
-      echo "Use generated Data types, precise local Props, unknown, or a generic type parameter instead."
-    fi
-
-    # Run Biome lint
-    if [ -f "$PROJECT_ROOT/node_modules/.bin/biome" ]; then
-      echo "📋 Linting: $(basename "$FILE_PATH")"
-      "$PROJECT_ROOT/node_modules/.bin/biome" lint "$FILE_PATH" 2>&1 || true
+  ts|tsx|js|jsx)
+    if [ -x "$APP_DIR/node_modules/.bin/biome" ]; then
+      echo "Linting: $(basename "$FILE_PATH")"
+      (cd "$APP_DIR" && ./node_modules/.bin/biome lint "$FILE_PATH" 2>&1) || true
     fi
     ;;
 esac

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,143 +1,124 @@
 #!/bin/bash
-# Pre-commit hook: Run lint and tests before allowing commit
-# Blocks commit if lint errors or test failures exist
-
-set -e
+# PreToolUse hook for `git commit`: architecture guards, lint and tests.
+# Exits 2 on failure so Claude Code actually blocks the commit.
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# shellcheck source=lib-project.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib-project.sh"
+
 ERRORS=0
+REPORT=""
+
+fail() {
+  REPORT="${REPORT}$1
+"
+  ERRORS=1
+}
 
 echo "=== Pre-commit Check ==="
 
-# Get staged files
-STAGED_PHP=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.php$' || true)
-STAGED_TS=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx|js|jsx)$' || true)
+STAGED_PHP=$(git -C "$PROJECT_DIR" diff --cached --name-only --diff-filter=ACMR | grep '\.php$' || true)
+STAGED_TS=$(git -C "$PROJECT_DIR" diff --cached --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx|js|jsx)$' || true)
 
-# PHP checks (Laravel)
 if [ -n "$STAGED_PHP" ]; then
-  echo ">>> PHP: Running Pint..."
-  cd "$PROJECT_DIR"
-
   SERVICE_LAYER_FILES=""
+  CONTROLLER_VALIDATION=""
+
   while IFS= read -r FILE; do
     [ -z "$FILE" ] && continue
 
     if [[ "$FILE" == src/app/Services/* || "$FILE" == src/app/Actions/* ]]; then
       SERVICE_LAYER_FILES="${SERVICE_LAYER_FILES}${FILE}
 "
-      continue
+    elif [[ "$FILE" == src/app/*Service.php && "$FILE" != src/app/Providers/*ServiceProvider.php ]]; then
+      SERVICE_LAYER_FILES="${SERVICE_LAYER_FILES}${FILE}
+"
     fi
 
-    if [[ "$FILE" == src/app/*Service.php || "$FILE" == src/app/**/*Service.php ]]; then
-      if [[ "$FILE" != src/app/Providers/*ServiceProvider.php ]]; then
-        SERVICE_LAYER_FILES="${SERVICE_LAYER_FILES}${FILE}
+    if [[ "$FILE" == src/app/Http/Controllers/*.php ]]; then
+      MATCHES=$(grep -nE '(\$request->validate\(|request\(\)->validate\()' "$PROJECT_DIR/$FILE" 2>/dev/null || true)
+      if [ -n "$MATCHES" ]; then
+        CONTROLLER_VALIDATION="${CONTROLLER_VALIDATION}${FILE}:${MATCHES}
 "
       fi
     fi
   done < <(printf '%s\n' "$STAGED_PHP")
+
   if [ -n "$SERVICE_LAYER_FILES" ]; then
-    echo "BLOCK: Service / Action classes are not allowed."
-    echo "$SERVICE_LAYER_FILES"
-    echo "Place DB logic in Eloquent Models, external API logic in Models/Gateway, and shared model behavior in Models/Concerns."
-    ERRORS=1
+    fail "BLOCK: Service / Action classes are not allowed.
+${SERVICE_LAYER_FILES}Place DB logic in Eloquent Models, external API logic in App\\Models\\Gateway, and shared model behavior in App\\Models\\Concerns."
   fi
 
-  CONTROLLER_VALIDATION=""
-  while IFS= read -r FILE; do
-    [ -z "$FILE" ] && continue
-    MATCHES=$(grep -nE '(\$request->validate\(|request\(\)->validate\()' "$FILE" 2>/dev/null || true)
-    if [ -n "$MATCHES" ]; then
-      CONTROLLER_VALIDATION="${CONTROLLER_VALIDATION}${FILE}:${MATCHES}
-"
-    fi
-  done < <(printf '%s\n' "$STAGED_PHP" | grep '^src/app/Http/Controllers/.*\.php$' || true)
   if [ -n "$CONTROLLER_VALIDATION" ]; then
-    echo "BLOCK: Controller input validation must use Form Request objects."
-    echo "$CONTROLLER_VALIDATION"
-    echo "Move rules to app/Http/Requests/** and read validated data with \$request->validated()."
-    ERRORS=1
+    fail "BLOCK: Controller input validation must use Form Request objects.
+${CONTROLLER_VALIDATION}Move rules to app/Http/Requests/** and read validated data with \$request->validated()."
   fi
 
-  if ! ./vendor/bin/pint --test 2>&1; then
-    echo "BLOCK: Pint found formatting issues. Run: composer pint"
-    ERRORS=1
-  fi
+  if ! php_tooling_available; then
+    fail "BLOCK: the app container is not running, so PHP checks cannot run.
+Start it with: docker compose up -d"
+  else
+    echo ">>> PHP: Running Pint..."
+    php_exec ./vendor/bin/pint --test 2>&1 || fail "BLOCK: Pint found formatting issues. Run: docker compose exec app ./vendor/bin/pint"
 
-  echo ">>> PHP: Running PHPStan..."
-  if ! ./vendor/bin/phpstan analyze --no-progress 2>&1; then
-    echo "BLOCK: PHPStan found issues"
-    ERRORS=1
-  fi
+    echo ">>> PHP: Running PHPStan..."
+    php_exec ./vendor/bin/phpstan analyse --no-progress --memory-limit=2G 2>&1 || fail "BLOCK: PHPStan found issues."
 
-  echo ">>> PHP: Running Pest tests..."
-  if ! php artisan test --stop-on-failure 2>&1; then
-    echo "BLOCK: Pest tests failed"
-    ERRORS=1
+    echo ">>> PHP: Running Pest..."
+    php_exec php artisan test --stop-on-failure 2>&1 || fail "BLOCK: Pest tests failed."
   fi
 fi
 
-# TypeScript/JavaScript checks (React)
 if [ -n "$STAGED_TS" ]; then
-  echo ">>> TypeScript: Running Biome lint..."
-  ORIGINAL_DIR=$(pwd)
-  cd "$PROJECT_DIR/src"
-
   TYPE_SAFETY_ERRORS=""
+
   while IFS= read -r FILE; do
     [ -z "$FILE" ] && continue
 
     ADDED_LINES=$(git -C "$PROJECT_DIR" diff --cached -U0 -- "$FILE" | grep '^+' | grep -v '^+++' || true)
+    [ -z "$ADDED_LINES" ] && continue
 
-    if [ -n "$ADDED_LINES" ]; then
-      ANY_MATCHES=$(printf '%s\n' "$ADDED_LINES" | grep -nE '(:| as |<|,|\(|\[|\{|=)\s*any\b|Array<\s*any\s*>|Record<[^>]*,\s*any\s*>' || true)
-      if [ -n "$ANY_MATCHES" ]; then
-        TYPE_SAFETY_ERRORS="${TYPE_SAFETY_ERRORS}${FILE}: TypeScript any is not allowed.
+    ANY_MATCHES=$(printf '%s\n' "$ADDED_LINES" | grep -nE '(:| as |<|,|\(|\[|\{|=)\s*any\b|Array<\s*any\s*>|Record<[^>]*,\s*any\s*>' || true)
+    if [ -n "$ANY_MATCHES" ]; then
+      TYPE_SAFETY_ERRORS="${TYPE_SAFETY_ERRORS}${FILE}: TypeScript any is not allowed.
 ${ANY_MATCHES}
 "
-      fi
+    fi
 
-      if [[ "$FILE" == src/resources/js/types/* && "$FILE" != src/resources/js/types/generated.d.ts && "$FILE" != src/resources/js/types/vite-env.d.ts ]]; then
-        MANUAL_TYPES=$(printf '%s\n' "$ADDED_LINES" | grep -nE '^\+\s*export\s+(interface|type)\s+' || true)
-        if [ -n "$MANUAL_TYPES" ]; then
-          TYPE_SAFETY_ERRORS="${TYPE_SAFETY_ERRORS}${FILE}: Manual exported types under resources/js/types are not allowed.
+    if [[ "$FILE" == src/resources/js/types/* \
+       && "$FILE" != src/resources/js/types/generated.d.ts \
+       && "$FILE" != src/resources/js/types/vite-env.d.ts ]]; then
+      MANUAL_TYPES=$(printf '%s\n' "$ADDED_LINES" | grep -nE '^\+\s*export\s+(interface|type)\s+' || true)
+      if [ -n "$MANUAL_TYPES" ]; then
+        TYPE_SAFETY_ERRORS="${TYPE_SAFETY_ERRORS}${FILE}: Manual exported types under resources/js/types are not allowed.
 ${MANUAL_TYPES}
 "
-        fi
       fi
     fi
   done < <(printf '%s\n' "$STAGED_TS")
+
   if [ -n "$TYPE_SAFETY_ERRORS" ]; then
-    echo "BLOCK: TypeScript types must come from Laravel Data generated types."
-    echo "$TYPE_SAFETY_ERRORS"
-    echo "Create app/Data/** with #[TypeScript], run php artisan typescript:transform, and avoid any."
-    ERRORS=1
+    fail "BLOCK: TypeScript types must come from Laravel Data generated types.
+${TYPE_SAFETY_ERRORS}Create app/Data/** with #[TypeScript], run php artisan typescript:transform, and avoid any."
   fi
 
-  if ! npm run lint:js 2>&1; then
-    echo "BLOCK: Biome lint failed"
-    ERRORS=1
-  fi
+  echo ">>> TypeScript: Running Biome lint..."
+  (cd "$APP_DIR" && npm run lint:js 2>&1) || fail "BLOCK: Biome lint failed."
 
   echo ">>> TypeScript: Type checking..."
-  if ! npm run types 2>&1; then
-    echo "BLOCK: TypeScript type check failed"
-    ERRORS=1
-  fi
+  (cd "$APP_DIR" && npm run types 2>&1) || fail "BLOCK: TypeScript type check failed."
 
   echo ">>> TypeScript: Running Vitest..."
-  if ! npm run test -- --run 2>&1; then
-    echo "BLOCK: Vitest tests failed"
-    ERRORS=1
-  fi
-
-  cd "$ORIGINAL_DIR"
+  (cd "$APP_DIR" && npm run test:unit 2>&1) || fail "BLOCK: Vitest tests failed."
 fi
 
 if [ $ERRORS -ne 0 ]; then
-  echo ""
-  echo "BLOCKED: Fix the above issues before committing."
-  echo "Use '/verify --quick' for quick lint-only validation."
-  exit 1
+  {
+    printf '%s' "$REPORT"
+    echo "BLOCKED: Fix the above issues before committing."
+  } >&2
+  exit 2
 fi
 
 echo "=== Pre-commit Check Passed ==="

--- a/.claude/skills/backend-guidelines/SKILL.md
+++ b/.claude/skills/backend-guidelines/SKILL.md
@@ -471,7 +471,7 @@ composer test          # Pest テスト
 # TypeScript
 npm run lint:js        # Biome lint
 npm run types          # 型チェック
-npm run test           # Vitest
+npm run test:unit      # Vitest
 ```
 
 ### 開発サーバー

--- a/.claude/skills/brand-guidelines/SKILL.md
+++ b/.claude/skills/brand-guidelines/SKILL.md
@@ -126,22 +126,28 @@ spacing: {
 
 ### Accessing Design Tokens
 
-```typescript
-import { colors, spacing, typography, effects } from '@/design-system/theme';
+Tailwind CSS v4 は CSS-first 設定。token は `resources/css/app.css` の `@theme` に定義し、
+コンポーネントからは Tailwind utility として参照する。TypeScript の theme オブジェクトは持たない。
 
-// Primary colors
-const primaryColor = colors.primary[500];
-const lightBackground = colors.neutral[50];
+```css
+/* resources/css/app.css */
+@theme {
+    --color-primary-500: oklch(58% 0.2 250);
+    --color-primary-600: oklch(50% 0.18 250);
+    --color-success: oklch(70% 0.25 145);
 
-// Semantic colors
-const successColor = colors.semantic.success;
-
-// Spacing
-const padding = spacing.medium; // 24px
-
-// Typography
-const headingFont = typography.fontFamily.display;
+    --spacing-medium: 24px;
+}
 ```
+
+```tsx
+<div className="bg-primary-500 p-medium text-white">
+    <span className="text-success">保存しました</span>
+</div>
+```
+
+JS 側から値そのものが必要になった場合だけ `getComputedStyle(document.documentElement)`
+で CSS variable を読む。token を TypeScript 側に二重定義しない。
 
 ### Effects & Glassmorphism
 
@@ -188,9 +194,11 @@ effects: {
 
 ## File Locations
 
-- **Theme Definition**: `resources/js/design-system/theme.ts`
-- **UI Components**: `resources/js/components/ui/`
-- **Design Tokens**: `resources/js/constants/designTokens.ts`
+- **Theme / Design Tokens**: `resources/css/app.css` の `@theme` block
+- **汎用 UI Components**: `resources/js/shared/components/`
+- **feature 固有 UI**: `resources/js/features/{feature}/components/`
+
+配置の正本は `.claude/rules/frontend/architecture.md`。
 
 ## Dark Mode
 

--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -6,191 +6,153 @@ license: MIT
 
 # Frontend Design Guide
 
-This skill guides creation of distinctive, production-grade frontend interfaces using modern design principles.
+このテンプレートの実際のスタックに沿って、質の高い UI を作るためのガイド。
 
+**Stack**: React 19 + TypeScript + Inertia.js v2 + Tailwind CSS v4 + Headless UI
 **Keywords**: frontend, react, design, UI, components, inertia, tailwind
+
+配置ルールは `.claude/rules/frontend/architecture.md` が正本。このファイルは見た目の作り方だけを扱う。
 
 ## Design Context
 
-**Stack**: React 19 + TypeScript + Inertia.js + Tailwind CSS v4
-**Design System**: Custom theme (`resources/js/design-system/theme.ts`)
+新しい画面を作る前に確認する。
 
-## Design Thinking
+- 誰がどの頻度で使う画面か
+- 一覧 / 入力 / 確認 / 結果のどれか
+- 読み込み中・空・エラーの 3 状態をどう出すか
+- キーボードだけで完了できるか
 
-Before coding, understand the context:
+## Design Tokens
 
-- **Purpose**: What problem does this interface solve?
-- **User Experience**: Design should be intuitive and accessible
-- **Consistency**: Follow established design patterns
-- **Accessibility**: Must meet WCAG 2.1 AA standards
+Tailwind v4 は CSS-first 設定。token は `resources/css/app.css` の `@theme` に定義し、コンポーネントからは通常の Tailwind utility として参照する。`tailwind.config.js` は存在しないので作らない。
 
-## Design Principles
+```css
+/* resources/css/app.css */
+@import "tailwindcss";
 
-### 1. Color System (OKLCH)
+@theme {
+    --font-sans: Figtree, ui-sans-serif, system-ui, sans-serif;
 
-Always use design tokens:
+    --color-brand-500: oklch(58% 0.2 250);
+    --color-brand-600: oklch(50% 0.18 250);
 
-```typescript
-import { colors } from '@/design-system/theme';
-
-// Primary colors
-const primaryColor = colors.primary[500];
-const background = colors.neutral[50];
-
-// Semantic colors
-const success = colors.semantic.success;
-const danger = colors.semantic.danger;
+    --radius-card: 0.75rem;
+}
 ```
-
-### 2. Typography
-
-Use the correct font for each context:
-
-- **Plus Jakarta Sans**: Headings, titles, hero text
-- **Inter**: Body text, paragraphs, UI elements
-- **JetBrains Mono**: Code, technical data, numbers
 
 ```tsx
-<h1 className="font-display text-4xl">Page Title</h1>
-<p className="font-body text-base">Body content...</p>
-<span className="font-mono text-lg">$1,234.56</span>
+<button className="bg-brand-500 hover:bg-brand-600 rounded-card px-4 py-2 text-white">
+    保存
+</button>
 ```
 
-### 3. Glassmorphism Effects
+やること:
 
-Modern, layered UI with backdrop blur:
+- 繰り返し使う色・角丸・影は `@theme` に足してから使う
+- 一度きりの装飾値だけ arbitrary value (`w-[37px]`) を許す
+- 2 回目に同じ値が出たら token へ昇格する
+
+やらないこと:
+
+- コンポーネント内に hex を直書きする
+- 存在しない token 名 (`font-display` など) を使う
+- 画面名を token 名に入れる (`--color-login-bg`)
+
+## Typography
+
+- 本文とラベルは `font-sans` (`--font-sans`)。既定は Figtree
+- 別の書体を足す場合は `@theme` に `--font-display` などを定義してから `font-display` を使う
+- 日本語を扱う画面では、長い語が container を押し広げないよう `truncate` / `break-words` の方針を決める
+
+## Color
+
+- 状態は色だけで表さない。アイコンかラベルを添える
+- テキストと背景のコントラストは WCAG 2.1 AA (4.5:1、大きい文字は 3:1) を満たす
+- semantic な名前を付ける (`--color-danger-500`)。`--color-red-2` のような並び番号にしない
+
+## Interaction
+
+- Headless UI (`@headlessui/react`) が入っている。Dialog / Menu / Combobox など focus trap と ARIA が要る UI は自作せずこれを使う
+- すべての interactive 要素に default / hover / focus-visible / active / disabled を用意する
+- `focus:outline-none` だけ書いて終わらせない。`focus-visible:ring-2` などの代替を必ず置く
+- 非同期操作には loading 状態を出し、二重送信を防ぐ
+
+## Motion
+
+- animation ライブラリは入れていない。CSS transition と Tailwind の `transition-*` / `animate-*` で組む
+- 動きは 150-250ms 程度に収める
+- `prefers-reduced-motion` を尊重する
 
 ```tsx
-<div className="backdrop-blur-md bg-white/70 dark:bg-neutral-900/70 rounded-2xl shadow-soft">
-  {/* Card content */}
-</div>
-```
-
-### 4. Spacing
-
-Use design tokens for consistent spacing:
-
-```typescript
-import { spacing } from '@/design-system/theme';
-
-// spacing.small = 8px
-// spacing.base = 16px
-// spacing.medium = 24px
-// spacing.large = 32px
-```
-
-### 5. Motion & Micro-interactions
-
-Use Framer Motion for smooth animations:
-
-```tsx
-import { motion } from 'framer-motion';
-
-<motion.div
-  initial={{ opacity: 0, y: 20 }}
-  animate={{ opacity: 1, y: 0 }}
-  transition={{ duration: 0.4, ease: 'easeOut' }}
->
-  {/* Content fades in gently */}
-</motion.div>
+<div className="transition-opacity duration-200 motion-reduce:transition-none">
 ```
 
 ## Component Hierarchy
 
-### 1. Primitives (`components/ui/`)
+`.claude/rules/frontend/architecture.md` の区分に従う。
 
-Radix-based, accessible primitives:
-- `button.tsx`, `input.tsx`, `dialog.tsx`, `select.tsx`
+| 種類 | 置き場所 |
+|---|---|
+| Inertia page entry | `Pages/**` |
+| feature 固有 UI / hook | `features/{feature}/components`, `features/{feature}/hooks` |
+| 2 箇所以上で使う汎用 UI | `shared/components` |
+| app shell / layout | `Layouts/**` |
 
-### 2. Composite Components
+feature をまたいで内部 component を直接 import しない。共有が必要になった時点で `shared` へ上げる。
 
-Brand-styled components combining primitives:
-- Cards, Forms, Modals, Navigation
+## Forms
 
-### 3. Feature Components
-
-Domain-specific components:
-- Data visualization
-- Forms and workflows
-- Dashboard widgets
+- 入力検証は Laravel の Form Request が正本。フロントで rule を二重実装しない
+- `@inertiajs/react` の `useForm` と Precognition を使い、`onBlur` で `validate('field')` を呼ぶ
+- error は field 直下に赤文字で出し、`aria-invalid` と `aria-describedby` を付ける
 
 ## Best Practices
 
-### DO
+DO:
 
-- Import design tokens - never hardcode colors
-- Use Radix UI primitives for accessibility
-- Apply `dark:` variants for dark mode support
-- Use `cn()` from `@/lib/utils` for conditional classes
-- Follow existing component patterns in the codebase
-- Use Inertia's `router` for navigation, not `<a>` tags
+- `@theme` の token を使う
+- 状態 (loading / empty / error) を最初から作る
+- `focus-visible` を残す
+- 画像に `alt`、icon-only button に `aria-label` を付ける
+- 日本語 copy は呼び出し側から props で渡す
 
-### DON'T
+DON'T:
 
-- Hardcode hex/RGB colors (use design tokens)
-- Skip accessibility (aria-labels, keyboard navigation)
-- Create new UI primitives (use existing ones)
-- Ignore mobile responsiveness
-- Use inline styles over Tailwind classes
-- Bypass the design system
+- 存在しないモジュール (`@/design-system/theme` など) を import する
+- hex / px をコンポーネントに直書きする
+- `any` を使う (`.claude/rules/type-safety.md`)
+- 手書きの型を `resources/js/types/**` に足す
+- Headless UI で足りる UI を自作する
 
-## File Organization
-
-```
-resources/js/
-├── components/
-│   ├── ui/              # Primitives (Radix-based)
-│   ├── forms/           # Form components
-│   └── layout/          # Layout components
-├── design-system/
-│   └── theme.ts         # Design tokens
-├── layouts/             # Page layouts
-├── pages/               # Inertia pages
-└── hooks/               # Custom React hooks
-```
-
-## Example: Card Component
+## Example
 
 ```tsx
-import { motion } from 'framer-motion';
-import { cn } from '@/lib/utils';
+import { type ReactNode } from "react";
 
-interface CardProps {
-  title: string;
-  description: string;
-  variant?: 'default' | 'elevated';
-}
+type CardProps = {
+    title: string;
+    description?: string;
+    action?: ReactNode;
+};
 
-export function Card({ title, description, variant = 'default' }: CardProps) {
-  return (
-    <motion.div
-      initial={{ opacity: 0, scale: 0.95 }}
-      animate={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.3 }}
-      className={cn(
-        'rounded-2xl p-6 backdrop-blur-md',
-        'bg-white/70 dark:bg-neutral-900/70',
-        'border border-neutral-200/50 dark:border-neutral-700/50',
-        variant === 'elevated' && 'shadow-lg'
-      )}
-    >
-      <h3 className="font-display text-xl font-bold mb-2">{title}</h3>
-      <p className="font-body text-neutral-600 dark:text-neutral-300">
-        {description}
-      </p>
-    </motion.div>
-  );
+export function Card({ title, description, action }: CardProps) {
+    return (
+        <section className="rounded-card border border-gray-200 bg-white p-6 shadow-sm transition-shadow duration-200 hover:shadow-md motion-reduce:transition-none">
+            <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+            {description ? <p className="mt-2 text-sm text-gray-600">{description}</p> : null}
+            {action ? <div className="mt-4">{action}</div> : null}
+        </section>
+    );
 }
 ```
 
 ## Quality Checklist
 
-Before completing UI work:
+画面を出す前に確認する。
 
-- [ ] Uses design tokens (not hardcoded values)
-- [ ] Accessible (keyboard nav, screen readers)
-- [ ] Responsive (mobile-first)
-- [ ] Dark mode supported
-- [ ] Motion is smooth and purposeful
-- [ ] TypeScript types are complete
-- [ ] Matches existing component patterns
+- [ ] `@theme` の token だけで色・角丸・影を表現した
+- [ ] loading / empty / error の 3 状態がある
+- [ ] キーボードだけで操作でき、focus が見える
+- [ ] コントラストが AA を満たす
+- [ ] 320px 幅で横スクロールしない
+- [ ] `npm run lint:js` / `npm run types` / `npm run lint:react-compiler` が通る

--- a/.claude/skills/tdd-methodology/SKILL.md
+++ b/.claude/skills/tdd-methodology/SKILL.md
@@ -809,6 +809,6 @@ This skill works with `/kiro:spec-impl`:
 composer lint      # Pint + PHPStan + Rector dry-run
 composer test      # Pest tests
 npm run lint       # Biome + ESLint
-npm run test       # Vitest tests
+npm run test:unit  # Vitest tests
 npm run types      # TypeScript check
 ```


### PR DESCRIPTION
## 背景

especially-me 側で hooks を検証していて、このテンプレート由来の hooks が **3 本とも実質 no-op** だと分かったので、テンプレート側を直します。

## 問題

| 症状 | 原因 |
|---|---|
| `post-edit-check.sh` が起動しない | mode `100644` で実行権限がない |
| Pint / PHPStan / Biome / tsc が一度も走っていない | Laravel アプリは `src/` 配下なのに `$CLAUDE_PROJECT_DIR/vendor/bin` と `$CLAUDE_PROJECT_DIR/node_modules/.bin` を見ていた |
| `BLOCK:` と出るのに commit が通る | Claude Code の hook で処理を止められるのは **exit 2** のみ。`exit 1` は非ブロッキングエラー |
| pre-commit の Vitest ステップが必ず失敗する | `npm run test` は未定義（定義は `test:unit`） |

結果として、Service クラス禁止 / Form Request 必須 / `any` 禁止 / 手書き型禁止のガードは**一度も commit を止めていません**でした。

## 修正

- `.claude/hooks/lib-project.sh` を追加し、`src/` 配下のパス解決と `docker compose exec -T app` 実行を共通化
- ホストに php が無い Docker 前提の構成なので、PHP ツールはコンテナ経由で実行
- アーキテクチャ違反は `exit 2` + stderr で Claude / commit に差し戻す
- lint 出力は従来どおり非ブロッキング
- コンテナ停止中は PHP チェックをスキップし、pre-commit では起動を促して block

### 実在しないコマンド・ファイル参照の是正

hooks と同じく「書いてあるが動かない」状態だったものを実態に合わせました。

- `commands/verify.md` / `commands/commit.md`: 未定義の `npm run lint:all` / `npm run lint:js:fix` / `npm run test` を、実在する `lint:js` `types` `lint:react-compiler` `lint:dead-code` `lint:duplication` `test:unit` `composer lint` に置換
- `skills/frontend-design`: `@/design-system/theme` / `font-display` / framer-motion など存在しないモジュール・utility 前提だったため、Tailwind v4 の CSS-first (`@theme` in `resources/css/app.css`) と Headless UI という実際の構成に書き直し
- `skills/brand-guidelines`: `resources/js/design-system/theme.ts` など実在しないパスを `@theme` と `rules/frontend/architecture.md` の配置に置換
- `skills/backend-guidelines` / `skills/tdd-methodology`: `npm run test` → `npm run test:unit`

## 検証

hook に実際の payload を流して確認しました。

```
Service クラス編集      -> exit 2 (BLOCK 出力)
any を含む .ts 編集     -> exit 2 (BLOCK 出力)
コンテナ停止中の .php   -> exit 0 (PHP チェックをスキップ)
```

`git ls-files -s` で 4 本すべて mode `100755` を確認済み。

## 補足

CI (`.github/workflows/ci.yml`) は Lint / Frontend Quality / Tests / Rector dry-run が既に揃っているので、この PR では触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ugu6t2qjHH7QX6TYX6LZwC